### PR TITLE
Factions

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm test

--- a/gridworld.code-workspace
+++ b/gridworld.code-workspace
@@ -7,5 +7,8 @@
 			"path": "../.."
 		}
 	],
-	"settings": {}
+	"settings": {
+		"prettier.useTabs": true,
+		"editor.insertSpaces": false
+	}
 }

--- a/info.js
+++ b/info.js
@@ -332,7 +332,7 @@ module.exports = {
 			forwardTo: "master",
 			responseProperties: {
 				ok: { type: "boolean" },
-				msg: { type: "string" },
+				message: { type: "string" },
 				factions: {
 					type: "array",
 					items: {
@@ -340,6 +340,20 @@ module.exports = {
 						properties: factionProperties,
 					},
 				},
+			},
+		}),
+		factionInvitePlayer: new libLink.Request({
+			type: "gridworld:faction_invite_player",
+			links: ["instance-slave", "slave-master"],
+			forwardTo: "master",
+			requestProperties: {
+				faction_id: { type: "string" },
+				player_name: { type: "string" },
+				role: { type: "string" },
+			},
+			responseProperties: {
+				ok: { type: "boolean" },
+				message: { type: "string" },
 			},
 		}),
 		claimServer: new libLink.Request({
@@ -353,7 +367,7 @@ module.exports = {
 			},
 			responseProperties: {
 				ok: { type: "boolean" },
-				msg: { type: "string" },
+				message: { type: "string" },
 			},
 		}),
 		unclaimServer: new libLink.Request({
@@ -366,7 +380,7 @@ module.exports = {
 			},
 			responseProperties: {
 				ok: { type: "boolean" },
-				msg: { type: "string" },
+				message: { type: "string" },
 			},
 		}),
 		joinGridworld: new libLink.Request({

--- a/info.js
+++ b/info.js
@@ -356,6 +356,19 @@ module.exports = {
 				msg: { type: "string" },
 			},
 		}),
+		unclaimServer: new libLink.Request({
+			type: "gridworld:unclaim_server",
+			links: ["instance-slave", "slave-master"],
+			forwardTo: "master",
+			requestProperties: {
+				instance_id: { type: "integer" },
+				player_name: { type: "string" },
+			},
+			responseProperties: {
+				ok: { type: "boolean" },
+				msg: { type: "string" },
+			},
+		}),
 		joinGridworld: new libLink.Request({
 			type: "gridworld:join_gridworld",
 			links: ["instance-slave", "slave-master"],

--- a/info.js
+++ b/info.js
@@ -356,6 +356,33 @@ module.exports = {
 				message: { type: "string" },
 			},
 		}),
+		leaveFaction: new libLink.Request({
+			type: "gridworld:leave_faction",
+			links: ["instance-slave", "slave-master"],
+			forwardTo: "master",
+			requestProperties: {
+				faction_id: { type: "string" },
+				player_name: { type: "string" },
+			},
+			responseProperties: {
+				ok: { type: "boolean" },
+				message: { type: "string" },
+			},
+		}),
+		factionChangeMemberRole: new libLink.Request({
+			type: "gridworld:faction_change_member_role",
+			links: ["instance-slave", "slave-master"],
+			forwardTo: "master",
+			requestProperties: {
+				faction_id: { type: "string" },
+				player_name: { type: "string" },
+				role: factionProperties.members.items.properties.role,
+			},
+			responseProperties: {
+				ok: { type: "boolean" },
+				message: { type: "string" },
+			},
+		}),
 		claimServer: new libLink.Request({
 			type: "gridworld:claim_server",
 			links: ["instance-slave", "slave-master"],

--- a/info.js
+++ b/info.js
@@ -262,6 +262,10 @@ module.exports = {
 				},
 			},
 		}),
+		/**
+		 * Send updated faction data to master for propagation throughout the cluster
+		 * Used to edit factions
+		 */
 		updateFaction: new libLink.Request({
 			type: "gridworld:update_faction",
 			links: ["instance-slave", "slave-master"],
@@ -289,6 +293,9 @@ module.exports = {
 				},
 			},
 		}),
+		/**
+		 * Event notifying an instance of changes to a faction
+		 */
 		factionUpdate: new libLink.Event({
 			type: "gridworld:faction_update",
 			links: ["master-slave", "slave-instance"],
@@ -297,6 +304,25 @@ module.exports = {
 				faction: {
 					type: "object",
 					properties: factionProperties,
+				},
+			},
+		}),
+		/**
+		 * Get changed factions
+		 */
+		refreshFactionData: new libLink.Request({
+			type: "gridworld:refresh_faction_data",
+			links: ["instance-slave", "slave-master"],
+			forwardTo: "master",
+			responseProperties: {
+				ok: { type: "boolean" },
+				msg: { type: "string" },
+				factions: {
+					type: "array",
+					items: {
+						type: "object",
+						properties: factionProperties,
+					},
 				},
 			},
 		}),

--- a/info.js
+++ b/info.js
@@ -125,6 +125,12 @@ libUsers.definePermission({
 	description: "Allow for existing instances to be started by exploration through edge_teleports",
 	grantByDefault: true,
 });
+libUsers.definePermission({
+	name: "gridworld.faction.delete",
+	title: "Delete faction",
+	description: "Delete *any* faction",
+	grantByDefault: false,
+});
 
 module.exports = {
 	name: "gridworld",
@@ -141,6 +147,8 @@ module.exports = {
 	routes: [
 		"/gridworld",
 		"/gridworld/create",
+		"/gridworld/factions",
+		"/gridworld/factions/:factionId/view",
 	],
 
 	messages: {
@@ -239,12 +247,13 @@ module.exports = {
 				y: { type: "number" },
 			},
 		}),
-		setPlayerPositionSubscription: new libLink.Request({
-			type: "gridworld:set_player_position_subscription",
+		setWebSubscription: new libLink.Request({
+			type: "gridworld:set_web_subscription",
 			links: ["control-master"],
 			permission: "gridworld.overview.view",
 			requestProperties: {
 				player_position: { type: "boolean" },
+				faction_list: { type: "boolean" },
 			},
 		}),
 		startInstance: new libLink.Request({
@@ -305,7 +314,7 @@ module.exports = {
 		 */
 		factionUpdate: new libLink.Event({
 			type: "gridworld:faction_update",
-			links: ["master-slave", "slave-instance"],
+			links: ["master-slave", "slave-instance", "master-control"],
 			broadcastTo: "instance",
 			eventProperties: {
 				faction: {

--- a/info.js
+++ b/info.js
@@ -356,6 +356,19 @@ module.exports = {
 				message: { type: "string" },
 			},
 		}),
+		joinFaction: new libLink.Request({
+			type: "gridworld:join_faction",
+			links: ["instance-slave", "slave-master"],
+			forwardTo: "master",
+			requestProperties: {
+				faction_id: { type: "string" },
+				player_name: { type: "string" },
+			},
+			responseProperties: {
+				ok: { type: "boolean" },
+				message: { type: "string" },
+			},
+		}),
 		leaveFaction: new libLink.Request({
 			type: "gridworld:leave_faction",
 			links: ["instance-slave", "slave-master"],

--- a/info.js
+++ b/info.js
@@ -86,6 +86,13 @@ InstanceConfigGroup.define({
 	type: "number",
 	initial_value: 0,
 });
+InstanceConfigGroup.define({
+	name: "claimed_by_faction",
+	title: "Claimed by faction",
+	description: "Faction that has claimed this server",
+	type: "string",
+	initial_value: "",
+});
 InstanceConfigGroup.finalize();
 
 libUsers.definePermission({
@@ -324,6 +331,20 @@ module.exports = {
 						properties: factionProperties,
 					},
 				},
+			},
+		}),
+		claimServer: new libLink.Request({
+			type: "gridworld:claim_server",
+			links: ["instance-slave", "slave-master"],
+			forwardTo: "master",
+			requestProperties: {
+				instance_id: { type: "integer" },
+				player_name: { type: "string" },
+				faction_id: { type: "string" },
+			},
+			responseProperties: {
+				ok: { type: "boolean" },
+				msg: { type: "string" },
 			},
 		}),
 		joinGridworld: new libLink.Request({

--- a/instance.js
+++ b/instance.js
@@ -33,6 +33,26 @@ class InstancePlugin extends libPlugin.BaseInstancePlugin {
 				`Error updating faction:\n${err.stack}`
 			));
 		});
+		this.instance.server.on("ipc-gridworld:faction_invite_player", data => {
+			this.factionInvitePlayer(data).catch(err => this.logger.error(
+				`Error inviting player to faction:\n${err.stack}`
+			));
+		});
+		this.instance.server.on("ipc-gridworld:faction_kick_player", data => {
+			this.factionKickPlayer(data).catch(err => this.logger.error(
+				`Error kicking player from faction:\n${err.stack}`
+			));
+		});
+		this.instance.server.on("ipc-gridworld:faction_promote_player", data => {
+			this.factionPromotePlayer(data).catch(err => this.logger.error(
+				`Error promoting player in faction:\n${err.stack}`
+			));
+		});
+		this.instance.server.on("ipc-gridworld:faction_demote_player", data => {
+			this.factionDemotePlayer(data).catch(err => this.logger.error(
+				`Error demoting player in faction:\n${err.stack}`
+			));
+		});
 		this.instance.server.on("ipc-gridworld:claim_server", data => {
 			this.claimServer(data).catch(err => this.logger.error(
 				`Error claiming server:\n${err.stack}`
@@ -193,6 +213,33 @@ class InstancePlugin extends libPlugin.BaseInstancePlugin {
 		await this.sendRcon(`/sc gridworld.open_faction_admin_screen("${data.player_name}","${data.faction_id}")`);
 	}
 
+	async factionInvitePlayer(data) {
+		let response = await this.info.messages.factionInvitePlayer.send(this.instance, {
+			faction_id: data.faction_id,
+			player_name: data.player_name,
+			role: data.role,
+		});
+		if (response.ok) {
+			// Close invite player dialog
+			await this.sendRcon(`/sc game.get_player("${data.requesting_player}").gui.center.gridworld_invite_player_dialog.destroy()`);
+		} else {
+			// Show error message
+			await this.sendRcon(`/sc game.get_player("${data.requesting_player}").print("${response.message}")`);
+		}
+	}
+
+	async factionKickPlayer(data) {
+
+	}
+
+	async factionPromotePlayer(data) {
+
+	}
+
+	async factionDemotePlayer(data) {
+
+	}
+
 	async claimServer(data) {
 		// Show received progress in game
 		await this.sendRcon(`/sc gridworld.show_progress("${data.player_name}", "Claiming server", "Propagating changes", 2, 3)`);
@@ -209,8 +256,8 @@ class InstancePlugin extends libPlugin.BaseInstancePlugin {
 			await this.sendRcon(`/sc game.get_player("${data.player_name}").gui.center.clear()`);
 		} else {
 			await this.sendRcon(`/sc gridworld.show_progress("${data.player_name}", "Claiming server", "Failed", 3, 3)`);
-			await this.sendRcon(`/sc game.get_player("${data.player_name}".print("Failed to claim server: ${status.msg}")`);
-			this.logger.error(`Failed to claim server: ${status.msg}`);
+			await this.sendRcon(`/sc game.get_player("${data.player_name}".print("Failed to claim server: ${status.message}")`);
+			this.logger.error(`Failed to claim server: ${status.message}`);
 		}
 	}
 
@@ -229,8 +276,8 @@ class InstancePlugin extends libPlugin.BaseInstancePlugin {
 			await this.sendRcon(`/sc game.get_player("${data.player_name}").gui.center.clear()`);
 		} else {
 			await this.sendRcon(`/sc gridworld.show_progress("${data.player_name}", "Unclaiming server", "Failed", 3, 3)`);
-			await this.sendRcon(`/sc game.get_player("${data.player_name}".print("Failed to unclaim server: ${status.msg}")`);
-			this.logger.error(`Failed to unclaim server: ${status.msg}`);
+			await this.sendRcon(`/sc game.get_player("${data.player_name}".print("Failed to unclaim server: ${status.message}")`);
+			this.logger.error(`Failed to unclaim server: ${status.message}`);
 		}
 	}
 

--- a/instance.js
+++ b/instance.js
@@ -38,6 +38,11 @@ class InstancePlugin extends libPlugin.BaseInstancePlugin {
 				`Error inviting player to faction:\n${err.stack}`
 			));
 		});
+		this.instance.server.on("ipc-gridworld:join_faction", data => {
+			this.joinFaction(data).catch(err => this.logger.error(
+				`Error joining faction:\n${err.stack}`
+			));
+		});
 		this.instance.server.on("ipc-gridworld:faction_kick_player", data => {
 			this.factionKickPlayer(data).catch(err => this.logger.error(
 				`Error kicking player from faction:\n${err.stack}`
@@ -220,6 +225,19 @@ class InstancePlugin extends libPlugin.BaseInstancePlugin {
 		} else {
 			// Show error message
 			await this.sendRcon(`/sc game.get_player("${data.requesting_player}").print("${response.message}")`);
+		}
+	}
+
+	async joinFaction(data) {
+		let response = await this.info.messages.joinFaction.send(this.instance, {
+			faction_id: data.faction_id,
+			player_name: data.player_name,
+		});
+		if (response.ok) {
+			await this.sendRcon(`/sc game.get_player("${data.player_name}").print("${response.message}")`);
+		} else {
+			// Show error message
+			await this.sendRcon(`/sc game.get_player("${data.player_name}").print("${response.message}")`);
 		}
 	}
 

--- a/instance.js
+++ b/instance.js
@@ -43,14 +43,9 @@ class InstancePlugin extends libPlugin.BaseInstancePlugin {
 				`Error kicking player from faction:\n${err.stack}`
 			));
 		});
-		this.instance.server.on("ipc-gridworld:faction_promote_player", data => {
-			this.factionPromotePlayer(data).catch(err => this.logger.error(
-				`Error promoting player in faction:\n${err.stack}`
-			));
-		});
-		this.instance.server.on("ipc-gridworld:faction_demote_player", data => {
-			this.factionDemotePlayer(data).catch(err => this.logger.error(
-				`Error demoting player in faction:\n${err.stack}`
+		this.instance.server.on("ipc-gridworld:faction_change_member_role", data => {
+			this.factionChangeMemberRole(data).catch(err => this.logger.error(
+				`Error changing player role in faction:\n${err.stack}`
 			));
 		});
 		this.instance.server.on("ipc-gridworld:claim_server", data => {
@@ -229,15 +224,26 @@ class InstancePlugin extends libPlugin.BaseInstancePlugin {
 	}
 
 	async factionKickPlayer(data) {
-
+		const response = await this.info.messages.leaveFaction.send(this.instance, {
+			faction_id: data.faction_id,
+			player_name: data.player_name,
+		});
+		if (!response.ok) {
+			// Show error message
+			await this.sendRcon(`/sc game.get_player("${data.requesting_player}").print("${response.message}")`);
+		}
 	}
 
-	async factionPromotePlayer(data) {
-
-	}
-
-	async factionDemotePlayer(data) {
-
+	async factionChangeMemberRole(data) {
+		const response = await this.info.messages.factionChangeMemberRole.send(this.instance, {
+			faction_id: data.faction_id,
+			player_name: data.player_name,
+			role: data.role,
+		});
+		if (!response.ok) {
+			// Show error message
+			await this.sendRcon(`/sc game.get_player("${data.requesting_player}").print("${response.message}")`);
+		}
 	}
 
 	async claimServer(data) {

--- a/instance.js
+++ b/instance.js
@@ -67,8 +67,8 @@ class InstancePlugin extends libPlugin.BaseInstancePlugin {
 				instance_id: this.instance.id,
 			});
 			// Refresh faction data
-			const factions = await this.info.messages.refreshFactionData.send(this.instance);
-			for (let faction of factions) {
+			const response = await this.info.messages.refreshFactionData.send(this.instance);
+			for (let faction of response.factions) {
 				await this.runTask(this.sendRcon(`/sc gridworld.sync_faction("${faction.faction_id}",'${libLuaTools.escapeString(JSON.stringify(faction))}')`));
 			}
 		}

--- a/instance.js
+++ b/instance.js
@@ -66,6 +66,11 @@ class InstancePlugin extends libPlugin.BaseInstancePlugin {
 			await this.info.messages.updateEdgeTransportEdges.send(this.instance, {
 				instance_id: this.instance.id,
 			});
+			// Refresh faction data
+			const factions = await this.info.messages.refreshFactionData.send(this.instance);
+			for (let faction of factions) {
+				await this.runTask(this.sendRcon(`/sc gridworld.sync_faction("${faction.faction_id}",'${libLuaTools.escapeString(JSON.stringify(faction))}')`));
+			}
 		}
 	}
 

--- a/master.js
+++ b/master.js
@@ -7,7 +7,7 @@ const registerTileServer = require("./src/routes/tileserver");
 
 const getMapDataRequestHandler = require("./src/request_handlers/getMapDataRequestHandler");
 const refreshTileDataRequestHandler = require("./src/request_handlers/refreshTileDataRequestHandler");
-const setPlayerPositionSubscriptionRequestHandler = require("./src/request_handlers/setPlayerPositionSubscriptionRequestHandler");
+const setWebSubscriptionRequestHandler = require("./src/request_handlers/setWebSubscriptionRequestHandler");
 const startInstanceRequestHandler = require("./src/request_handlers/startInstanceRequestHandler");
 const createFactionRequestHandler = require("./src/request_handlers/createFactionRequestHandler");
 const updateFactionRequestHandler = require("./src/request_handlers/updateFactionRequestHandler");
@@ -67,7 +67,7 @@ class MasterPlugin extends libPlugin.BaseMasterPlugin {
 
 		registerTileServer(this.master.app, this._tilesPath);
 
-		this.subscribedControlLinks = new Set();
+		this.subscribedControlLinks = [];
 	}
 
 	playerPositionEventHandler = playerPositionEventHandler;
@@ -80,7 +80,7 @@ class MasterPlugin extends libPlugin.BaseMasterPlugin {
 
 	refreshTileDataRequestHandler = refreshTileDataRequestHandler;
 
-	setPlayerPositionSubscriptionRequestHandler = setPlayerPositionSubscriptionRequestHandler;
+	setWebSubscriptionRequestHandler = setWebSubscriptionRequestHandler;
 
 	startInstanceRequestHandler = startInstanceRequestHandler;
 
@@ -155,7 +155,8 @@ class MasterPlugin extends libPlugin.BaseMasterPlugin {
 
 	onControlConnectionEvent(connection, event) {
 		if (event === "close") {
-			this.subscribedControlLinks.delete(connection);
+			let index = this.subscribedControlLinks.indexOf(sub => sub.link === connection);
+			if (index !== -1) { this.subscribedControlLinks.splice(index, 1); }
 		}
 	}
 

--- a/master.js
+++ b/master.js
@@ -19,6 +19,7 @@ const performEdgeTeleportRequestHandler = require("./src/request_handlers/perfor
 const updateEdgeTransportEdgesRequestHandler = require("./src/request_handlers/updateEdgeTransportEdgesRequestHandler");
 const refreshFactionDataRequestHandler = require("./src/request_handlers/refreshFactionDataRequestHandler");
 const claimServerRequestHandler = require("./src/request_handlers/claimServerRequestHandler");
+const unclaimServerRequestHandler = require("./src/request_handlers/unclaimServerRequestHandler");
 
 async function loadDatabase(config, filename, logger) {
 	let itemsPath = path.resolve(config.get("master.database_directory"), filename);
@@ -97,6 +98,8 @@ class MasterPlugin extends libPlugin.BaseMasterPlugin {
 	refreshFactionDataRequestHandler = refreshFactionDataRequestHandler;
 
 	claimServerRequestHandler = claimServerRequestHandler;
+
+	unclaimServerRequestHandler = unclaimServerRequestHandler;
 
 	async onInstanceStatusChanged(instance) {
 		if (instance.status === "running") {

--- a/master.js
+++ b/master.js
@@ -18,6 +18,7 @@ const joinGridworldRequestHandler = require("./src/request_handlers/joinGridworl
 const performEdgeTeleportRequestHandler = require("./src/request_handlers/performEdgeTeleportRequestHandler");
 const updateEdgeTransportEdgesRequestHandler = require("./src/request_handlers/updateEdgeTransportEdgesRequestHandler");
 const refreshFactionDataRequestHandler = require("./src/request_handlers/refreshFactionDataRequestHandler");
+const factionInvitePlayerRequestHandler = require("./src/request_handlers/factionInvitePlayerRequestHandler");
 const claimServerRequestHandler = require("./src/request_handlers/claimServerRequestHandler");
 const unclaimServerRequestHandler = require("./src/request_handlers/unclaimServerRequestHandler");
 
@@ -96,6 +97,8 @@ class MasterPlugin extends libPlugin.BaseMasterPlugin {
 	performEdgeTeleportRequestHandler = performEdgeTeleportRequestHandler;
 
 	refreshFactionDataRequestHandler = refreshFactionDataRequestHandler;
+
+	factionInvitePlayerRequestHandler = factionInvitePlayerRequestHandler;
 
 	claimServerRequestHandler = claimServerRequestHandler;
 

--- a/master.js
+++ b/master.js
@@ -19,6 +19,7 @@ const performEdgeTeleportRequestHandler = require("./src/request_handlers/perfor
 const updateEdgeTransportEdgesRequestHandler = require("./src/request_handlers/updateEdgeTransportEdgesRequestHandler");
 const refreshFactionDataRequestHandler = require("./src/request_handlers/refreshFactionDataRequestHandler");
 const factionInvitePlayerRequestHandler = require("./src/request_handlers/factionInvitePlayerRequestHandler");
+const joinFactionRequestHandler = require("./src/request_handlers/joinFactionRequestHandler");
 const factionChangeMemberRoleRequestHandler = require("./src/request_handlers/factionChangeMemberRoleRequestHandler");
 const leaveFactionRequestHandler = require("./src/request_handlers/leaveFactionRequestHandler");
 const claimServerRequestHandler = require("./src/request_handlers/claimServerRequestHandler");
@@ -101,6 +102,8 @@ class MasterPlugin extends libPlugin.BaseMasterPlugin {
 	refreshFactionDataRequestHandler = refreshFactionDataRequestHandler;
 
 	factionInvitePlayerRequestHandler = factionInvitePlayerRequestHandler;
+
+	joinFactionRequestHandler = joinFactionRequestHandler;
 
 	factionChangeMemberRoleRequestHandler = factionChangeMemberRoleRequestHandler;
 

--- a/master.js
+++ b/master.js
@@ -18,6 +18,7 @@ const joinGridworldRequestHandler = require("./src/request_handlers/joinGridworl
 const performEdgeTeleportRequestHandler = require("./src/request_handlers/performEdgeTeleportRequestHandler");
 const updateEdgeTransportEdgesRequestHandler = require("./src/request_handlers/updateEdgeTransportEdgesRequestHandler");
 const refreshFactionDataRequestHandler = require("./src/request_handlers/refreshFactionDataRequestHandler");
+const claimServerRequestHandler = require("./src/request_handlers/claimServerRequestHandler");
 
 async function loadDatabase(config, filename, logger) {
 	let itemsPath = path.resolve(config.get("master.database_directory"), filename);
@@ -94,6 +95,8 @@ class MasterPlugin extends libPlugin.BaseMasterPlugin {
 	performEdgeTeleportRequestHandler = performEdgeTeleportRequestHandler;
 
 	refreshFactionDataRequestHandler = refreshFactionDataRequestHandler;
+
+	claimServerRequestHandler = claimServerRequestHandler;
 
 	async onInstanceStatusChanged(instance) {
 		if (instance.status === "running") {

--- a/master.js
+++ b/master.js
@@ -17,6 +17,7 @@ const createFactionGridRequestHandler = require("./src/request_handlers/createFa
 const joinGridworldRequestHandler = require("./src/request_handlers/joinGridworldRequestHandler");
 const performEdgeTeleportRequestHandler = require("./src/request_handlers/performEdgeTeleportRequestHandler");
 const updateEdgeTransportEdgesRequestHandler = require("./src/request_handlers/updateEdgeTransportEdgesRequestHandler");
+const refreshFactionDataRequestHandler = require("./src/request_handlers/refreshFactionDataRequestHandler");
 
 async function loadDatabase(config, filename, logger) {
 	let itemsPath = path.resolve(config.get("master.database_directory"), filename);
@@ -91,6 +92,8 @@ class MasterPlugin extends libPlugin.BaseMasterPlugin {
 	joinGridworldRequestHandler = joinGridworldRequestHandler;
 
 	performEdgeTeleportRequestHandler = performEdgeTeleportRequestHandler;
+
+	refreshFactionDataRequestHandler = refreshFactionDataRequestHandler;
 
 	async onInstanceStatusChanged(instance) {
 		if (instance.status === "running") {

--- a/master.js
+++ b/master.js
@@ -19,6 +19,8 @@ const performEdgeTeleportRequestHandler = require("./src/request_handlers/perfor
 const updateEdgeTransportEdgesRequestHandler = require("./src/request_handlers/updateEdgeTransportEdgesRequestHandler");
 const refreshFactionDataRequestHandler = require("./src/request_handlers/refreshFactionDataRequestHandler");
 const factionInvitePlayerRequestHandler = require("./src/request_handlers/factionInvitePlayerRequestHandler");
+const factionChangeMemberRoleRequestHandler = require("./src/request_handlers/factionChangeMemberRoleRequestHandler");
+const leaveFactionRequestHandler = require("./src/request_handlers/leaveFactionRequestHandler");
 const claimServerRequestHandler = require("./src/request_handlers/claimServerRequestHandler");
 const unclaimServerRequestHandler = require("./src/request_handlers/unclaimServerRequestHandler");
 
@@ -99,6 +101,10 @@ class MasterPlugin extends libPlugin.BaseMasterPlugin {
 	refreshFactionDataRequestHandler = refreshFactionDataRequestHandler;
 
 	factionInvitePlayerRequestHandler = factionInvitePlayerRequestHandler;
+
+	factionChangeMemberRoleRequestHandler = factionChangeMemberRoleRequestHandler;
+
+	leaveFactionRequestHandler = leaveFactionRequestHandler;
 
 	claimServerRequestHandler = claimServerRequestHandler;
 

--- a/module/faction/building_restrictions/on_built_entity.lua
+++ b/module/faction/building_restrictions/on_built_entity.lua
@@ -1,0 +1,42 @@
+local get_player_faction = require("modules/gridworld/faction/get_player_faction")
+
+local function owner_faction_is_allowed(_entity)
+	return true
+end
+
+local function guest_faction_is_allowed(_entity)
+	return false
+end
+
+local function can_build_entity(entity, player)
+	-- Get claiming faction
+	local claiming_faction_id = global.gridworld.claiming_faction.faction_id
+	local faction = get_player_faction(player)
+	if claiming_faction_id == faction.faction_id then
+		return owner_faction_is_allowed(entity)
+	end
+	return guest_faction_is_allowed(entity)
+end
+
+local function on_built_entity(event)
+	-- Don't do anything if the server isn't claimed
+	if not global.gridworld.claiming_faction.claimed then
+		return
+	end
+
+	local entity = event.created_entity
+	local player = game.get_player(event.player_index)
+
+	if not can_build_entity(entity, player) then
+		-- Return item to player
+		local inventory = player.get_main_inventory()
+		if inventory ~= nil then
+			player.mine_entity(entity, true)
+		end
+		-- Destroy entity without remnants
+		if entity ~= nil and entity.valid and entity.can_be_destroyed() then entity.destroy() end
+		player.print("You cannot build this entity on this server.")
+	end
+end
+
+return on_built_entity

--- a/module/faction/claim_server.lua
+++ b/module/faction/claim_server.lua
@@ -1,0 +1,18 @@
+local get_player_faction = require("modules/gridworld/faction/get_player_faction")
+local faction_server_status = require("modules/gridworld/faction/gui/faction_server_status/dialog")
+
+local function claim_server(faction_id)
+	global.gridworld.claiming_faction.claimed = true
+	global.gridworld.claiming_faction.faction_id = faction_id
+	global.gridworld.claiming_faction.claim_start = game.tick
+	global.gridworld.claiming_faction.claim_cost = 100 -- TODO: Calculate this based on the size of the map
+	global.gridworld.claiming_faction.stored_fp = 1000
+
+    -- Redraw server status and other GUI elements that show the claiming faction
+	-- TODO: Only draw for players who have the GUI open
+	for _, player in pairs(game.players) do
+		faction_server_status.draw(player, get_player_faction(player).faction_id)
+	end
+end
+
+return claim_server

--- a/module/faction/claim_server.lua
+++ b/module/faction/claim_server.lua
@@ -8,7 +8,7 @@ local function claim_server(faction_id)
 	global.gridworld.claiming_faction.claim_cost = 100 -- TODO: Calculate this based on the size of the map
 	global.gridworld.claiming_faction.stored_fp = 1000
 
-    -- Redraw server status and other GUI elements that show the claiming faction
+	-- Redraw server status and other GUI elements that show the claiming faction
 	-- TODO: Only draw for players who have the GUI open
 	for _, player in pairs(game.players) do
 		faction_server_status.draw(player, get_player_faction(player).faction_id)

--- a/module/faction/get_player_faction.lua
+++ b/module/faction/get_player_faction.lua
@@ -2,7 +2,7 @@ local function get_player_faction(player)
 	local factions = global.gridworld.factions
 	for _, v in pairs(factions) do
 		for _, member in pairs(v.members) do
-			if member.name == player.name then
+			if member.name:lower() == player.name:lower() then
 				return v
 			end
 		end

--- a/module/faction/get_player_faction.lua
+++ b/module/faction/get_player_faction.lua
@@ -1,0 +1,14 @@
+local function get_player_faction(player)
+	local factions = global.gridworld.factions
+	for _, v in pairs(factions) do
+        for _, member in pairs(v.members) do
+			game.print("member: "..member.name.." player: "..player.name)
+			if member.name == player.name then
+				return v
+			end
+		end
+	end
+	return nil
+end
+
+return get_player_faction

--- a/module/faction/get_player_faction.lua
+++ b/module/faction/get_player_faction.lua
@@ -1,7 +1,7 @@
 local function get_player_faction(player)
 	local factions = global.gridworld.factions
 	for _, v in pairs(factions) do
-        for _, member in pairs(v.members) do
+		for _, member in pairs(v.members) do
 			game.print("member: "..member.name.." player: "..player.name)
 			if member.name == player.name then
 				return v

--- a/module/faction/get_player_faction.lua
+++ b/module/faction/get_player_faction.lua
@@ -2,7 +2,6 @@ local function get_player_faction(player)
 	local factions = global.gridworld.factions
 	for _, v in pairs(factions) do
 		for _, member in pairs(v.members) do
-			game.print("member: "..member.name.." player: "..player.name)
 			if member.name == player.name then
 				return v
 			end

--- a/module/faction/gui.lua
+++ b/module/faction/gui.lua
@@ -19,7 +19,8 @@ return {
 	on_gui_click = function (event, action, player)
 		run_function("on_gui_click", dialog_faction_admin_screen.events, event, action, player)
 		run_function("on_gui_click", factions_table.events, event, action, player)
-		run_function("on_gui_click", faction_edit_screen.events, event, action, player)
+        run_function("on_gui_click", faction_edit_screen.events, event, action, player)
+		run_function("on_gui_click", dialog_faction_server_status.events, event, action, player)
 	end,
 	on_gui_checked_state_changed = function (event, action, player)
 		run_function("on_gui_checked_state_changed", faction_edit_screen.events, event, action, player)

--- a/module/faction/gui.lua
+++ b/module/faction/gui.lua
@@ -19,7 +19,7 @@ return {
 	on_gui_click = function (event, action, player)
 		run_function("on_gui_click", dialog_faction_admin_screen.events, event, action, player)
 		run_function("on_gui_click", factions_table.events, event, action, player)
-        run_function("on_gui_click", faction_edit_screen.events, event, action, player)
+		run_function("on_gui_click", faction_edit_screen.events, event, action, player)
 		run_function("on_gui_click", dialog_faction_server_status.events, event, action, player)
 	end,
 	on_gui_checked_state_changed = function (event, action, player)

--- a/module/faction/gui.lua
+++ b/module/faction/gui.lua
@@ -6,6 +6,7 @@ local dialog_faction_admin_screen = require("gui/faction_admin_screen/dialog")
 local dialog_faction_server_status = require("gui/faction_server_status/dialog")
 local factions_table = require("gui/components/factions_table/index")
 local faction_edit_screen = require("gui/faction_edit_screen/dialog")
+local invite_player_dialog = require("gui/invite_player_dialog/dialog")
 
 local run_function = function (key, table, event, action, player)
 	if table[key] ~= nil then
@@ -21,6 +22,7 @@ return {
 		run_function("on_gui_click", factions_table.events, event, action, player)
 		run_function("on_gui_click", faction_edit_screen.events, event, action, player)
 		run_function("on_gui_click", dialog_faction_server_status.events, event, action, player)
+		run_function("on_gui_click", invite_player_dialog.events, event, action, player)
 	end,
 	on_gui_checked_state_changed = function (event, action, player)
 		run_function("on_gui_checked_state_changed", faction_edit_screen.events, event, action, player)

--- a/module/faction/gui/components/factions_table/draw.lua
+++ b/module/faction/gui/components/factions_table/draw.lua
@@ -50,7 +50,7 @@ local function draw_factions_table()
 		-- Get player count
 		local playercount = 0
 		for _,v in pairs(faction.members) do
-			if v.rank ~= "invited" then -- Invited but not accepted is not counted as a member
+			if v.role ~= "invited" then -- Invited but not accepted is not counted as a member
 				playercount = playercount + 1
 			end
 		end

--- a/module/faction/gui/faction_admin_screen/dialog.lua
+++ b/module/faction/gui/faction_admin_screen/dialog.lua
@@ -1,7 +1,21 @@
 local draw = require("modules/gridworld/faction/gui/faction_admin_screen/draw")
 local events = require("modules/gridworld/faction/gui/faction_admin_screen/events")
+local get_player_faction = require("modules/gridworld/faction/get_player_faction")
+
+local function update(player)
+	local faction = get_player_faction(player)
+	if faction == nil then
+		return
+	end
+	local frame = player.gui.center["gridworld_faction_admin_screen"]
+	if frame == nil then
+		return
+	end
+	draw(player, faction.faction_id)
+end
 
 return {
 	draw = draw,
-	events = events,
+    events = events,
+	update = update,
 }

--- a/module/faction/gui/faction_admin_screen/dialog.lua
+++ b/module/faction/gui/faction_admin_screen/dialog.lua
@@ -16,6 +16,6 @@ end
 
 return {
 	draw = draw,
-    events = events,
+	events = events,
 	update = update,
 }

--- a/module/faction/gui/faction_admin_screen/draw.lua
+++ b/module/faction/gui/faction_admin_screen/draw.lua
@@ -2,7 +2,7 @@ local gui = require("modules/gridworld/flib/gui")
 local get_faction = require("modules/gridworld/faction/get_faction")
 
 local function get_members_table(faction, player)
-    local members = {
+	local members = {
 		type = "table",
 		name = "gridworld_faction_members_table",
 		column_count = 3,
@@ -18,12 +18,12 @@ local function get_members_table(faction, player)
 			type = "label",
 			caption = "Actions",
 		},
-    }
-    local player_role = "member"
+	}
+	local player_role = "member"
 	for _, member in pairs(faction.members) do
 		if member.name:lower() == player.name:lower() then
 			player_role = member.role
-        end
+		end
 	end
 
 	for _, member in pairs(faction.members) do
@@ -37,7 +37,7 @@ local function get_members_table(faction, player)
 		})
 		local buttons = {
 			type = "flow",
-            direction = "horizontal",
+			direction = "horizontal",
 		}
 		if player_role == "leader" or (player_role == "officer" and member.role == "member") then
 			table.insert(buttons, {
@@ -47,11 +47,11 @@ local function get_members_table(faction, player)
 					on_click = {
 						location = "faction_admin_screen",
 						action = "kick_member",
-                        player = member.name,
+						player = member.name,
 						faction_id = faction.faction_id,
 					}
 				}
-            })
+			})
 			if member.role ~= "leader" and member.role ~= "invited" then
 				table.insert(buttons, {
 					type = "button",
@@ -60,7 +60,7 @@ local function get_members_table(faction, player)
 						on_click = {
 							location = "faction_admin_screen",
 							action = "promote_member",
-                            player = member.name,
+							player = member.name,
 							old_role = member.role,
 							faction_id = faction.faction_id,
 						}
@@ -81,7 +81,7 @@ local function get_members_table(faction, player)
 						}
 					}
 				})
-            end
+			end
 		elseif player.name == member.name then
 			table.insert(buttons, {
 				type = "button",
@@ -90,14 +90,14 @@ local function get_members_table(faction, player)
 					on_click = {
 						location = "faction_admin_screen",
 						action = "kick_member",
-                        player = member.name,
+						player = member.name,
 						faction_id = faction.faction_id,
 					}
 				}
 			})
 		end
 		table.insert(members, buttons)
-    end
+	end
 	return members
 end
 
@@ -108,13 +108,13 @@ local function draw_faction_admin_screen(player, faction_id)
 	local faction = get_faction(faction_id)
 
 	local selected_tab_index = 1
-    if player.gui.center["gridworld_faction_admin_screen"] ~= nil then
+	if player.gui.center["gridworld_faction_admin_screen"] ~= nil then
 		selected_tab_index = player.gui.center["gridworld_faction_admin_screen"].content.faction_tabs.selected_tab_index
 		player.gui.center["gridworld_faction_admin_screen"].destroy()
 	end
 	gui.build(player.gui.center, {
 		{
-            type = "frame",
+			type = "frame",
 			name = "gridworld_faction_admin_screen",
 			direction = "vertical",
 			ref = {"window"},
@@ -166,13 +166,13 @@ local function draw_faction_admin_screen(player, faction_id)
 			},
 			-- Content
 			{
-                type = "flow",
+				type = "flow",
 				name = "content",
 				{
-                    type = "tabbed-pane",
+					type = "tabbed-pane",
 					name = "faction_tabs",
 					style_mods = {
-                        maximal_width = 750,
+						maximal_width = 750,
 						height = 500,
 					},
 					-- User customizable front page and statistics
@@ -182,7 +182,7 @@ local function draw_faction_admin_screen(player, faction_id)
 							type = "flow",
 							direction = "vertical",
 							style_mods = {
-                                maximal_height = 450,
+								maximal_height = 450,
 								natural_height = 450,
 							},
 							{
@@ -210,8 +210,8 @@ local function draw_faction_admin_screen(player, faction_id)
 								},
 							},
 						}
-                    },
-                    -- Members
+					},
+					-- Members
 					{
 						tab = { type = "tab", caption = "Members" },
 						content = {
@@ -222,8 +222,8 @@ local function draw_faction_admin_screen(player, faction_id)
 								natural_height = 450,
 							},
 							{
-                                type = "button",
-                                caption = "Invite player",
+								type = "button",
+								caption = "Invite player",
 								actions = {
 									on_click = {
 										location = "faction_admin_screen",
@@ -231,7 +231,7 @@ local function draw_faction_admin_screen(player, faction_id)
 										faction_id = faction_id,
 									}
 								}
-                            },
+							},
 							{
 								type = "button",
 								caption = "Join faction",
@@ -249,7 +249,7 @@ local function draw_faction_admin_screen(player, faction_id)
 				},
 			}
 		}
-    })
+	})
 	player.gui.center["gridworld_faction_admin_screen"].content.faction_tabs.selected_tab_index = selected_tab_index
 end
 -- /c game.player.gui.screen.clear()

--- a/module/faction/gui/faction_admin_screen/draw.lua
+++ b/module/faction/gui/faction_admin_screen/draw.lua
@@ -231,6 +231,17 @@ local function draw_faction_admin_screen(player, faction_id)
 										faction_id = faction_id,
 									}
 								}
+                            },
+							{
+								type = "button",
+								caption = "Join faction",
+								actions = {
+									on_click = {
+										location = "faction_admin_screen",
+										action = "join_faction",
+										faction_id = faction_id,
+									}
+								}
 							},
 							get_members_table(faction, player),
 						}

--- a/module/faction/gui/faction_admin_screen/draw.lua
+++ b/module/faction/gui/faction_admin_screen/draw.lua
@@ -1,6 +1,76 @@
 local gui = require("modules/gridworld/flib/gui")
 local get_faction = require("modules/gridworld/faction/get_faction")
 
+local function get_members_table(faction)
+    local members = {
+		type = "table",
+		name = "gridworld_faction_members_table",
+		column_count = 3,
+		{
+			type = "label",
+			caption = "Name",
+		},
+		{
+			type = "label",
+			caption = "Role",
+		},
+		{
+			type = "label",
+			caption = "Actions",
+		},
+    }
+
+	for _, member in pairs(faction.members) do
+		table.insert(members, {
+			type = "label",
+			caption = member.name,
+		})
+		table.insert(members, {
+			type = "label",
+			caption = member.role,
+		})
+		local buttons = {
+			type = "flow",
+			direction = "horizontal",
+			{
+				type = "button",
+				caption = "Kick",
+				actions = {
+					on_click = {
+						location = "faction_admin_screen",
+						action = "kick_member",
+						player = member.name,
+					}
+				}
+			},
+			{
+				type = "button",
+				caption = "Promote",
+				actions = {
+					on_click = {
+						location = "faction_admin_screen",
+						action = "promote_member",
+						player = member.name,
+					}
+				}
+			},
+			{
+				type = "button",
+				caption = "Demote",
+				actions = {
+					on_click = {
+						location = "faction_admin_screen",
+						action = "demote_member",
+						player = member.name,
+					}
+				}
+			},
+		}
+		table.insert(members, buttons)
+    end
+	return members
+end
+
 local function draw_faction_admin_screen(player, faction_id)
 	if player == nil then player = game.player end
 	if player == nil then return false end
@@ -65,7 +135,7 @@ local function draw_faction_admin_screen(player, faction_id)
 				{
 					type = "tabbed-pane",
 					style_mods = {
-						maximal_width = 750,
+                        maximal_width = 750,
 						height = 500,
 					},
 					elem_mods = {
@@ -78,7 +148,7 @@ local function draw_faction_admin_screen(player, faction_id)
 							type = "flow",
 							direction = "vertical",
 							style_mods = {
-								maximal_height = 450,
+                                maximal_height = 450,
 								natural_height = 450,
 							},
 							{
@@ -105,6 +175,30 @@ local function draw_faction_admin_screen(player, faction_id)
 									single_line = false,
 								},
 							},
+						}
+                    },
+                    -- Members
+					{
+						tab = { type = "tab", caption = "Members" },
+						content = {
+							type = "flow",
+							direction = "vertical",
+							style_mods = {
+								maximal_height = 450,
+								natural_height = 450,
+							},
+							{
+                                type = "button",
+                                caption = "Invite player",
+								actions = {
+									on_click = {
+										location = "faction_admin_screen",
+										action = "invite_player",
+										faction_id = faction_id,
+									}
+								}
+							},
+							get_members_table(faction),
 						}
 					},
 				},

--- a/module/faction/gui/faction_admin_screen/events.lua
+++ b/module/faction/gui/faction_admin_screen/events.lua
@@ -1,5 +1,7 @@
+local clusterio_api = require("modules/clusterio/api")
 local dialog_welcome_draw = require("modules/gridworld/lobby/gui/dialog_welcome/draw")
 local dialog_faction_edit_screen_draw = require("modules/gridworld/faction/gui/faction_edit_screen/draw")
+local invite_player_dialog_draw = require("modules/gridworld/faction/gui/invite_player_dialog/draw")
 
 local function on_gui_click(_, action, player)
 	if player == nil then return end
@@ -10,6 +12,34 @@ local function on_gui_click(_, action, player)
 		if action.action == "edit_faction" then
 			-- Open edit dialog
 			dialog_faction_edit_screen_draw(player, action.faction_id)
+        end
+		if action.action == "invite_player" then
+            -- Open invite dialog
+			invite_player_dialog_draw(player)
+        end
+		if action.action == "kick_member" then
+            -- Kick the member from the faction - should maybe have a confirmation dialog?
+			clusterio_api.send_json("gridworld:faction_kick_player", {
+				faction_id = action.faction_id,
+				player_name = action.player,
+				requesting_player = player.name,
+			})
+        end
+		if action.action == "promote_member" then
+            -- Promote one step
+			clusterio_api.send_json("gridworld:faction_promote_player", {
+				faction_id = action.faction_id,
+				player_name = action.player,
+				requesting_player = player.name,
+			})
+		end
+		if action.action == "demote_member" then
+            -- Demote one step
+			clusterio_api.send_json("gridworld:faction_demote_player", {
+				faction_id = action.faction_id,
+				player_name = action.player,
+				requesting_player = player.name,
+			})
 		end
 	end
 end

--- a/module/faction/gui/faction_admin_screen/events.lua
+++ b/module/faction/gui/faction_admin_screen/events.lua
@@ -4,12 +4,12 @@ local dialog_faction_edit_screen_draw = require("modules/gridworld/faction/gui/f
 local invite_player_dialog_draw = require("modules/gridworld/faction/gui/invite_player_dialog/draw")
 
 local function indexOf(array, value)
-    for i, v in ipairs(array) do
-        if v == value then
-            return i
-        end
-    end
-    return nil
+	for i, v in ipairs(array) do
+		if v == value then
+			return i
+		end
+	end
+	return nil
 end
 
 local function on_gui_click(_, action, player)
@@ -21,11 +21,11 @@ local function on_gui_click(_, action, player)
 		if action.action == "edit_faction" then
 			-- Open edit dialog
 			dialog_faction_edit_screen_draw(player, action.faction_id)
-        end
+		end
 		if action.action == "invite_player" then
-            -- Open invite dialog
+			-- Open invite dialog
 			invite_player_dialog_draw(player)
-        end
+		end
 		if action.action == "join_faction" then
 			-- Join faction
 			clusterio_api.send_json("gridworld:join_faction", {
@@ -34,31 +34,31 @@ local function on_gui_click(_, action, player)
 			})
 		end
 		if action.action == "kick_member" then
-            -- Kick the member from the faction - should maybe have a confirmation dialog?
+			-- Kick the member from the faction - should maybe have a confirmation dialog?
 			clusterio_api.send_json("gridworld:faction_kick_player", {
 				faction_id = action.faction_id,
 				player_name = action.player,
 				requesting_player = player.name,
 			})
-        end
+		end
 		if action.action == "promote_member" then
-            -- Promote one step
+			-- Promote one step
 			local roleTable = {"leader", "officer", "member", "invited"}
 			local role = indexOf(roleTable, action.old_role)
 			clusterio_api.send_json("gridworld:faction_change_member_role", {
 				faction_id = action.faction_id,
-                player_name = action.player,
+				player_name = action.player,
 				role = roleTable[role - 1],
 				requesting_player = player.name,
 			})
 		end
 		if action.action == "demote_member" then
-            -- Demote one step
+			-- Demote one step
 			local roleTable = {"leader", "officer", "member", "invited"}
 			local role = indexOf(roleTable, action.old_role)
 			clusterio_api.send_json("gridworld:faction_change_member_role", {
 				faction_id = action.faction_id,
-                player_name = action.player,
+				player_name = action.player,
 				role = roleTable[role + 1],
 				requesting_player = player.name,
 			})

--- a/module/faction/gui/faction_admin_screen/events.lua
+++ b/module/faction/gui/faction_admin_screen/events.lua
@@ -26,6 +26,13 @@ local function on_gui_click(_, action, player)
             -- Open invite dialog
 			invite_player_dialog_draw(player)
         end
+		if action.action == "join_faction" then
+			-- Join faction
+			clusterio_api.send_json("gridworld:join_faction", {
+				faction_id = action.faction_id,
+				player_name = player.name,
+			})
+		end
 		if action.action == "kick_member" then
             -- Kick the member from the faction - should maybe have a confirmation dialog?
 			clusterio_api.send_json("gridworld:faction_kick_player", {

--- a/module/faction/gui/faction_admin_screen/events.lua
+++ b/module/faction/gui/faction_admin_screen/events.lua
@@ -3,6 +3,15 @@ local dialog_welcome_draw = require("modules/gridworld/lobby/gui/dialog_welcome/
 local dialog_faction_edit_screen_draw = require("modules/gridworld/faction/gui/faction_edit_screen/draw")
 local invite_player_dialog_draw = require("modules/gridworld/faction/gui/invite_player_dialog/draw")
 
+local function indexOf(array, value)
+    for i, v in ipairs(array) do
+        if v == value then
+            return i
+        end
+    end
+    return nil
+end
+
 local function on_gui_click(_, action, player)
 	if player == nil then return end
 	if action.location == "faction_admin_screen" then
@@ -27,17 +36,23 @@ local function on_gui_click(_, action, player)
         end
 		if action.action == "promote_member" then
             -- Promote one step
-			clusterio_api.send_json("gridworld:faction_promote_player", {
+			local roleTable = {"leader", "officer", "member", "invited"}
+			local role = indexOf(roleTable, action.old_role)
+			clusterio_api.send_json("gridworld:faction_change_member_role", {
 				faction_id = action.faction_id,
-				player_name = action.player,
+                player_name = action.player,
+				role = roleTable[role - 1],
 				requesting_player = player.name,
 			})
 		end
 		if action.action == "demote_member" then
             -- Demote one step
-			clusterio_api.send_json("gridworld:faction_demote_player", {
+			local roleTable = {"leader", "officer", "member", "invited"}
+			local role = indexOf(roleTable, action.old_role)
+			clusterio_api.send_json("gridworld:faction_change_member_role", {
 				faction_id = action.faction_id,
-				player_name = action.player,
+                player_name = action.player,
+				role = roleTable[role + 1],
 				requesting_player = player.name,
 			})
 		end

--- a/module/faction/gui/faction_edit_screen/events.lua
+++ b/module/faction/gui/faction_edit_screen/events.lua
@@ -5,7 +5,7 @@ local function on_gui_click(_, action, player)
 	if player == nil then return end
 	if action.location == "faction_edit_screen" then
 		if action.action == "return_to_faction_screen" then
-            -- Close dialog
+			-- Close dialog
 			player.gui.center.clear()
 			gridworld.open_faction_admin_screen(player.name, action.faction_id)
 		end
@@ -20,8 +20,8 @@ local function on_gui_click(_, action, player)
 				open = faction.open,
 				about = faction.about,
 				player_name = player.name,
-            })
-            -- Close dialog
+			})
+			-- Close dialog
 			player.gui.center.clear()
 		end
 	end

--- a/module/faction/gui/faction_edit_screen/events.lua
+++ b/module/faction/gui/faction_edit_screen/events.lua
@@ -5,6 +5,8 @@ local function on_gui_click(_, action, player)
 	if player == nil then return end
 	if action.location == "faction_edit_screen" then
 		if action.action == "return_to_faction_screen" then
+            -- Close dialog
+			player.gui.center.clear()
 			gridworld.open_faction_admin_screen(player.name, action.faction_id)
 		end
 		if action.action == "save_faction" then
@@ -18,7 +20,9 @@ local function on_gui_click(_, action, player)
 				open = faction.open,
 				about = faction.about,
 				player_name = player.name,
-			})
+            })
+            -- Close dialog
+			player.gui.center.clear()
 		end
 	end
 end

--- a/module/faction/gui/faction_server_status/dialog.lua
+++ b/module/faction/gui/faction_server_status/dialog.lua
@@ -1,7 +1,21 @@
 local draw = require("modules/gridworld/faction/gui/faction_server_status/draw")
 local events = require("modules/gridworld/faction/gui/faction_server_status/events")
+local get_player_faction = require("modules/gridworld/faction/get_player_faction")
+
+local function update(player)
+	local faction = get_player_faction(player)
+	if faction == nil then
+		return
+	end
+	local frame = player.gui.left["gridworld_faction_server_status"]
+	if frame == nil then
+		return
+	end
+	draw(player, faction.faction_id)
+end
 
 return {
 	draw = draw,
 	events = events,
+	update = update,
 }

--- a/module/faction/gui/faction_server_status/draw.lua
+++ b/module/faction/gui/faction_server_status/draw.lua
@@ -7,13 +7,14 @@ local function draw_faction_server_status(player, faction_id)
 	if player == nil then return false end
 
 	local player_faction = get_faction(faction_id)
-    local server_is_claimed = global.gridworld.claiming_faction.claimed
+	local server_is_claimed = global.gridworld.claiming_faction.claimed
 	local claiming_faction = get_faction(global.gridworld.claiming_faction.faction_id)
 	local server_is_claimed_by_player = server_is_claimed and global.gridworld.claiming_faction.faction_id == faction_id
 
 	local content = {
 		type = "flow",
-        direction = "vertical",
+		direction = "vertical",
+		name = "gridworld_faction_server_status",
 		{
 			type = "button",
 			caption = "Join lobby server",
@@ -53,12 +54,13 @@ local function draw_faction_server_status(player, faction_id)
 			})
 		end
 	else
-		-- Server is not claimed, are we part of a faction that can claim it?
+		-- Server is not claimed
+		table.insert(content, {
+			type = "label",
+			caption = "Unclaimed server",
+		})
+		-- are we part of a faction that can claim it?
 		if player_faction ~= nil then
-			table.insert(content, {
-				type = "label",
-				caption = "Unclaimed server",
-			})
 			table.insert(content, {
 				type = "button",
 				name = "gridworld_faction_claim_server",
@@ -71,11 +73,6 @@ local function draw_faction_server_status(player, faction_id)
 						player = player.name,
 					}
 				},
-			})
-		else
-			table.insert(content, {
-				type = "label",
-				caption = "Unclaimed server",
 			})
 		end
 	end

--- a/module/faction/gui/faction_server_status/draw.lua
+++ b/module/faction/gui/faction_server_status/draw.lua
@@ -118,17 +118,6 @@ local function draw_faction_server_status(player, faction_id)
 						horizontal_align = "right",
 						horizontally_stretchable = true,
 					},
-					-- {
-					-- 	type = "sprite-button",
-					-- 	sprite = "utility/confirm_slot",
-					-- 	style = "tool_button",
-					-- 	actions = {
-					-- 		on_click = {
-					-- 			location = "faction_server_status",
-					-- 			action = "save_faction",
-					-- 		}
-					-- 	},
-					-- },
 					{
 						type = "sprite-button",
 						sprite = "utility/close_white",

--- a/module/faction/gui/faction_server_status/draw.lua
+++ b/module/faction/gui/faction_server_status/draw.lua
@@ -13,7 +13,18 @@ local function draw_faction_server_status(player, faction_id)
 
 	local content = {
 		type = "flow",
-		direction = "vertical",
+        direction = "vertical",
+		{
+			type = "button",
+			caption = "Join lobby server",
+			style = "green_button",
+			actions = {
+				on_click = {
+					location = "faction_server_status",
+					action = "join_lobby_server",
+				},
+			},
+		},
 		{
 			type = "label",
 			caption = "Server name: "..clusterio_api.get_instance_name(),

--- a/module/faction/gui/faction_server_status/draw.lua
+++ b/module/faction/gui/faction_server_status/draw.lua
@@ -47,6 +47,19 @@ local function draw_faction_server_status(player, faction_id)
 				type = "label",
 				caption = "Cost per day: " .. 100 .. " fp",
 			})
+			table.insert(content, {
+				type = "button",
+				name = "gridworld_faction_unclaim_server",
+				caption = "Unclaim server",
+				actions = {
+					on_click = {
+						location = "faction_server_status",
+						action = "unclaim_server",
+						faction_id = faction_id,
+						player = player.name,
+					}
+				},
+			})
 		else
 			table.insert(content, {
 				type = "label",

--- a/module/faction/gui/faction_server_status/draw.lua
+++ b/module/faction/gui/faction_server_status/draw.lua
@@ -95,6 +95,7 @@ local function draw_faction_server_status(player, faction_id)
 	gui.build(player.gui.left, {
 		{
 			type = "frame",
+			name = "gridworld_faction_server_status",
 			direction = "vertical",
 			ref = {"window"},
 			-- Header

--- a/module/faction/gui/faction_server_status/events.lua
+++ b/module/faction/gui/faction_server_status/events.lua
@@ -1,19 +1,25 @@
+local clusterio_api = require("modules/clusterio/api")
 local util_gui = require("modules/gridworld/util/gui")
+local get_player_faction = require("modules/gridworld/faction/get_player_faction")
 
 local function on_gui_click(_, action, player)
 	if player == nil then return end
 	if action.location == "faction_server_status" then
 		if action.action == "close" then
 			player.gui.left.clear()
-        end
+		end
 		if action.action == "join_lobby_server" then
 			player.connect_to_server({address = "localhost:10000", name = "Lobby server"}) -- TODO: Use correct lobby address here
 		end
-		if action.action == "claim_sector" then
+		if action.action == "claim_server" then
 			-- Open claim dialog
-			player.print("Claiming sector...")
-            util_gui.dialog_show_progress.draw(player.name, "Claiming sector", "Sending changes to cluster", 1, 3)
-			-- TODO: Claim sector
+			player.print("Claiming server...")
+			local faction = get_player_faction(player)
+			util_gui.dialog_show_progress.draw(player.name, "Claiming server", "Sending changes to cluster", 1, 3)
+			clusterio_api.send_json("gridworld:claim_server", {
+				faction_id = faction.faction_id,
+				player_name = player.name,
+			})
 		end
 	end
 end

--- a/module/faction/gui/faction_server_status/events.lua
+++ b/module/faction/gui/faction_server_status/events.lua
@@ -4,7 +4,10 @@ local function on_gui_click(_, action, player)
 	if player == nil then return end
 	if action.location == "faction_server_status" then
 		if action.action == "close" then
-			game.player.gui.left.clear()
+			player.gui.left.clear()
+        end
+		if action.action == "join_lobby_server" then
+			player.connect_to_server({address = "localhost:10000", name = "Lobby server"}) -- TODO: Use correct lobby address here
 		end
 		if action.action == "claim_sector" then
 			-- Open claim dialog

--- a/module/faction/gui/faction_server_status/events.lua
+++ b/module/faction/gui/faction_server_status/events.lua
@@ -13,10 +13,18 @@ local function on_gui_click(_, action, player)
 		end
 		if action.action == "claim_server" then
 			-- Open claim dialog
-			player.print("Claiming server...")
 			local faction = get_player_faction(player)
 			util_gui.dialog_show_progress.draw(player.name, "Claiming server", "Sending changes to cluster", 1, 3)
 			clusterio_api.send_json("gridworld:claim_server", {
+				faction_id = faction.faction_id,
+				player_name = player.name,
+			})
+        end
+		if action.action == "unclaim_server" then
+			-- Open unclaim dialog
+			local faction = get_player_faction(player)
+			util_gui.dialog_show_progress.draw(player.name, "Unclaiming server", "Sending changes to cluster", 1, 3)
+			clusterio_api.send_json("gridworld:unclaim_server", {
 				faction_id = faction.faction_id,
 				player_name = player.name,
 			})

--- a/module/faction/gui/faction_server_status/events.lua
+++ b/module/faction/gui/faction_server_status/events.lua
@@ -19,7 +19,7 @@ local function on_gui_click(_, action, player)
 				faction_id = faction.faction_id,
 				player_name = player.name,
 			})
-        end
+		end
 		if action.action == "unclaim_server" then
 			-- Open unclaim dialog
 			local faction = get_player_faction(player)

--- a/module/faction/gui/invite_player_dialog/dialog.lua
+++ b/module/faction/gui/invite_player_dialog/dialog.lua
@@ -1,0 +1,7 @@
+local draw = require("modules/gridworld/faction/gui/invite_player_dialog/draw")
+local events = require("modules/gridworld/faction/gui/invite_player_dialog/events")
+
+return {
+	draw = draw,
+	events = events,
+}

--- a/module/faction/gui/invite_player_dialog/draw.lua
+++ b/module/faction/gui/invite_player_dialog/draw.lua
@@ -43,7 +43,7 @@ local function draw_invite_player_dialog(player)
 			},
 			-- Content
 			{
-                type = "flow",
+				type = "flow",
 				name = "content",
 				{
 					type = "table",
@@ -63,8 +63,8 @@ local function draw_invite_player_dialog(player)
 					},
 					{
 						type = "drop-down",
-                        name = "gridworld_invite_player_role",
-                        items = { "Leader", "Officer", "Member" },
+						name = "gridworld_invite_player_role",
+						items = { "Leader", "Officer", "Member" },
 						selected_index = 3,
 						actions = {
 							on_selection_state_changed = {
@@ -72,7 +72,7 @@ local function draw_invite_player_dialog(player)
 								action = "update_role",
 							}
 						},
-                    },
+					},
 					{
 						type = "label",
 						caption = "",
@@ -80,7 +80,7 @@ local function draw_invite_player_dialog(player)
 					{
 						type = "button",
 						name = "gridworld_invite_player_button",
-                        caption = "Invite",
+						caption = "Invite",
 						actions = {
 							on_click = {
 								location = "invite_player_dialog",

--- a/module/faction/gui/invite_player_dialog/draw.lua
+++ b/module/faction/gui/invite_player_dialog/draw.lua
@@ -1,0 +1,97 @@
+local gui = require("modules/gridworld/flib/gui")
+
+local function draw_invite_player_dialog(player)
+	gui.build(player.gui.center, {
+		{
+			type = "frame",
+			name = "gridworld_invite_player_dialog",
+			direction = "vertical",
+			ref = {"window"},
+			-- Header
+			{
+				type = "flow",
+				direction = "horizontal",
+				{
+					type = "flow",
+					direction = "horizontal",
+					{
+						type = "label",
+						style = "frame_title",
+						caption = "Invite player to faction",
+						ignored_by_interaction = true,
+					},
+				},
+				{
+					type = "flow",
+					direction = "horizontal",
+					style_mods = {
+						horizontal_align = "right",
+						horizontally_stretchable = true,
+					},
+					{
+						type = "sprite-button",
+						sprite = "utility/close_white",
+						style = "frame_action_button",
+						actions = {
+							on_click = {
+								location = "invite_player_dialog",
+								action = "close_dialog",
+							}
+						},
+					},
+				},
+			},
+			-- Content
+			{
+                type = "flow",
+				name = "content",
+				{
+					type = "table",
+					name = "gridworld_invite_player_table",
+					column_count = 2,
+					{
+						type = "label",
+						caption = "Player name",
+					},
+					{
+						type = "textfield",
+						name = "gridworld_invite_player_textfield",
+					},
+					{
+						type = "label",
+						caption = "Role",
+					},
+					{
+						type = "drop-down",
+                        name = "gridworld_invite_player_role",
+                        items = { "Leader", "Officer", "Member" },
+						selected_index = 3,
+						actions = {
+							on_selection_state_changed = {
+								location = "invite_player_dialog",
+								action = "update_role",
+							}
+						},
+                    },
+					{
+						type = "label",
+						caption = "",
+					},
+					{
+						type = "button",
+						name = "gridworld_invite_player_button",
+                        caption = "Invite",
+						actions = {
+							on_click = {
+								location = "invite_player_dialog",
+								action = "invite_button",
+							}
+						},
+					},
+				},
+			},
+		},
+	})
+end
+
+return draw_invite_player_dialog

--- a/module/faction/gui/invite_player_dialog/events.lua
+++ b/module/faction/gui/invite_player_dialog/events.lua
@@ -6,19 +6,19 @@ local function on_gui_click(_, action, player)
 	if action.location == "invite_player_dialog" then
 		if action.action == "close_dialog" then
 			player.gui.center.gridworld_invite_player_dialog.destroy()
-        end
+		end
 		if action.action == "invite_button" then
-            local faction = get_player_faction(player)
-            local table = player.gui.center
+			local faction = get_player_faction(player)
+			local table = player.gui.center
 				.gridworld_invite_player_dialog
-                .content
+				.content
 				.gridworld_invite_player_table
-            local name = table.gridworld_invite_player_textfield.text
+			local name = table.gridworld_invite_player_textfield.text
 			local role = table.gridworld_invite_player_role.selected_index
-            clusterio_api.send_json("gridworld:faction_invite_player", {
+			clusterio_api.send_json("gridworld:faction_invite_player", {
 				faction_id = faction.faction_id,
-                player_name = name,
-                role = ({"leader", "officer", "member", "invited"})[role],
+				player_name = name,
+				role = ({"leader", "officer", "member", "invited"})[role],
 				requesting_player = player.name,
 			})
 		end
@@ -26,5 +26,5 @@ local function on_gui_click(_, action, player)
 end
 
 return {
-    on_gui_click = on_gui_click,
+	on_gui_click = on_gui_click,
 }

--- a/module/faction/gui/invite_player_dialog/events.lua
+++ b/module/faction/gui/invite_player_dialog/events.lua
@@ -1,0 +1,30 @@
+local clusterio_api = require("modules/clusterio/api")
+local get_player_faction = require("modules/gridworld/faction/get_player_faction")
+
+local function on_gui_click(_, action, player)
+	if player == nil then return end
+	if action.location == "invite_player_dialog" then
+		if action.action == "close_dialog" then
+			player.gui.center.gridworld_invite_player_dialog.destroy()
+        end
+		if action.action == "invite_button" then
+            local faction = get_player_faction(player)
+            local table = player.gui.center
+				.gridworld_invite_player_dialog
+                .content
+				.gridworld_invite_player_table
+            local name = table.gridworld_invite_player_textfield.text
+			local role = table.gridworld_invite_player_role.selected_index
+            clusterio_api.send_json("gridworld:faction_invite_player", {
+				faction_id = faction.faction_id,
+                player_name = name,
+                role = ({"leader", "officer", "member", "invited"})[role],
+				requesting_player = player.name,
+			})
+		end
+	end
+end
+
+return {
+    on_gui_click = on_gui_click,
+}

--- a/module/faction/sync_faction.lua
+++ b/module/faction/sync_faction.lua
@@ -18,13 +18,13 @@ local function sync_faction(faction_id, faction_data)
 	for k,v in pairs(global.gridworld.factions[faction_id].members) do
 		local member = game.get_player(v.name)
 		if member ~= nil then
-            -- Apply faction settings to player
+			-- Apply faction settings to player
 
-            -- If server is claimed by the players faction, move player to the faction force
+			-- If server is claimed by the players faction, move player to the faction force
 			if global.gridworld.claiming_faction.claimed and global.gridworld.claiming_faction.faction_id == faction_id then
 				member.force = "faction_claimed"
 			end
-        end
+		end
 	end
 end
 

--- a/module/faction/sync_faction.lua
+++ b/module/faction/sync_faction.lua
@@ -7,6 +7,8 @@
 	The neutral faction is used by all players that aren't part of the server owner faction.
 ]]
 
+local faction_admin_screen = require("modules/gridworld/faction/gui/faction_admin_screen/dialog")
+
 local function sync_faction(faction_id, faction_data)
 	log("Syncing faction " .. faction_id)
 	if global.gridworld.factions == nil then
@@ -16,13 +18,16 @@ local function sync_faction(faction_id, faction_data)
 
 	-- Add members to the force
 	for k,v in pairs(global.gridworld.factions[faction_id].members) do
-		local member = game.get_player(v.name)
-		if member ~= nil then
+		local player = game.get_player(v.name)
+		if player ~= nil then
 			-- Apply faction settings to player
+
+			-- Update faction related GUIs
+			faction_admin_screen.update(player)
 
 			-- If server is claimed by the players faction, move player to the faction force
 			if global.gridworld.claiming_faction.claimed and global.gridworld.claiming_faction.faction_id == faction_id then
-				member.force = "faction_claimed"
+				player.force = "faction_claimed"
 			end
 		end
 	end

--- a/module/faction/sync_faction.lua
+++ b/module/faction/sync_faction.lua
@@ -8,6 +8,7 @@
 ]]
 
 local faction_admin_screen = require("modules/gridworld/faction/gui/faction_admin_screen/dialog")
+local faction_server_status = require("modules/gridworld/faction/gui/faction_server_status/dialog")
 
 local function sync_faction(faction_id, faction_data)
 	log("Syncing faction " .. faction_id)
@@ -29,6 +30,11 @@ local function sync_faction(faction_id, faction_data)
 			if global.gridworld.claiming_faction.claimed and global.gridworld.claiming_faction.faction_id == faction_id then
 				player.force = "faction_claimed"
 			end
+		end
+	end
+	for _, player in pairs(game.players) do
+		if player.connected then
+			faction_server_status.update(player)
 		end
 	end
 end

--- a/module/faction/sync_faction.lua
+++ b/module/faction/sync_faction.lua
@@ -8,6 +8,7 @@
 ]]
 
 local function sync_faction(faction_id, faction_data)
+	log("Syncing faction " .. faction_id)
 	if global.gridworld.factions == nil then
 		global.gridworld.factions = {}
 	end

--- a/module/faction/unclaim_server.lua
+++ b/module/faction/unclaim_server.lua
@@ -1,0 +1,19 @@
+local get_player_faction = require("modules/gridworld/faction/get_player_faction")
+local faction_server_status = require("modules/gridworld/faction/gui/faction_server_status/dialog")
+
+local function unclaim_server(faction_id)
+	if faction_id ~= global.gridworld.claiming_faction.faction_id then
+		game.print("Error: Attempted to unclaim server using the wrong faction")
+	end
+	global.gridworld.claiming_faction.claimed = false
+	global.gridworld.claiming_faction.faction_id = 0
+	global.gridworld.claiming_faction.stored_fp = 0
+
+	-- Redraw server status and other GUI elements that show the claiming faction
+	-- TODO: Only draw for players who have the GUI open
+	for _, player in pairs(game.players) do
+		faction_server_status.draw(player, get_player_faction(player).faction_id)
+	end
+end
+
+return unclaim_server

--- a/module/faction/unclaim_server.lua
+++ b/module/faction/unclaim_server.lua
@@ -6,7 +6,7 @@ local function unclaim_server(faction_id)
 		game.print("Error: Attempted to unclaim server using the wrong faction")
 	end
 	global.gridworld.claiming_faction.claimed = false
-	global.gridworld.claiming_faction.faction_id = 0
+	global.gridworld.claiming_faction.faction_id = ""
 	global.gridworld.claiming_faction.stored_fp = 0
 
 	-- Redraw server status and other GUI elements that show the claiming faction

--- a/module/factions.lua
+++ b/module/factions.lua
@@ -1,5 +1,6 @@
 local sync_faction = require("faction/sync_faction")
 local gui = require("faction/gui")
+local on_built_entity = require("faction/building_restrictions/on_built_entity")
 
 return {
 	sync_faction = sync_faction,
@@ -7,4 +8,5 @@ return {
 		gui.dialog_faction_admin_screen.draw(game.get_player(player_name), faction_id)
 	end,
 	gui = gui,
+	on_built_entity = on_built_entity,
 }

--- a/module/factions.lua
+++ b/module/factions.lua
@@ -9,4 +9,9 @@ return {
 	end,
 	gui = gui,
 	on_built_entity = on_built_entity,
+	on_player_joined_game = function(event)
+		local player = game.get_player(event.player_index)
+		if player == nil then return end
+		gui.dialog_faction_server_status.update(player)
+	end,
 }

--- a/module/gridworld.lua
+++ b/module/gridworld.lua
@@ -23,6 +23,7 @@ local factions = require("factions")
 local util_gui = require("util/gui")
 local setup_forces = require("faction/setup_forces")
 local claim_server = require("faction/claim_server")
+local unclaim_server = require("faction/unclaim_server")
 local get_player_faction = require("faction/get_player_faction")
 
 -- Declare globals to make linter happy
@@ -171,5 +172,6 @@ gridworld.hmi_hide_status = function()
 	game.player.gui.left.clear()
 end
 gridworld.claim_server = claim_server
+gridworld.unclaim_server = unclaim_server
 
 return gridworld

--- a/module/gridworld.lua
+++ b/module/gridworld.lua
@@ -110,6 +110,8 @@ gridworld.events[defines.events.on_built_entity] = function(event)
 				-- it wasn't placed by a player, we can't tell em whats wrong
 				entity.destroy()
 			end
+		else
+			factions.on_built_entity(event)
 		end
 	end
 end

--- a/module/gridworld.lua
+++ b/module/gridworld.lua
@@ -166,7 +166,7 @@ gridworld.sync_faction = factions.sync_faction
 gridworld.open_faction_admin_screen = factions.open_faction_admin_screen
 gridworld.show_progress = util_gui.dialog_show_progress.draw
 gridworld.hmi_show_status = function()
-	factions.gui.dialog_faction_server_status.draw(game.get_player("Danielv123"), get_player_faction(game.get_player("Danielv123")).faction_id)
+	factions.gui.dialog_faction_server_status.draw(game.player, get_player_faction(game.player).faction_id)
 end
 gridworld.hmi_hide_status = function()
 	game.player.gui.left.clear()

--- a/module/gridworld.lua
+++ b/module/gridworld.lua
@@ -123,7 +123,8 @@ gridworld.events[defines.events.on_gui_checked_state_changed] = function(event)
 	local player = game.players[event.player_index]
 	local action = gui.read_action(event)
 	if action then
-		lobby.gui.on_gui_checked_state_changed(event, action, player)
+        lobby.gui.on_gui_checked_state_changed(event, action, player)
+		factions.gui.on_gui_checked_state_changed(event, action, player)
 	end
 end
 gridworld.events[defines.events.on_gui_text_changed] = function(event)
@@ -131,6 +132,7 @@ gridworld.events[defines.events.on_gui_text_changed] = function(event)
 	local action = gui.read_action(event)
 	if action then
 		lobby.gui.on_gui_text_changed(event, action, player)
+		factions.gui.on_gui_text_changed(event, action, player)
 	end
 end
 gridworld.on_nth_tick = {}

--- a/module/gridworld.lua
+++ b/module/gridworld.lua
@@ -22,6 +22,8 @@ local lobby = require("lobby")
 local factions = require("factions")
 local util_gui = require("util/gui")
 local setup_forces = require("faction/setup_forces")
+local claim_server = require("faction/claim_server")
+local get_player_faction = require("faction/get_player_faction")
 
 -- Declare globals to make linter happy
 game = game
@@ -123,7 +125,7 @@ gridworld.events[defines.events.on_gui_checked_state_changed] = function(event)
 	local player = game.players[event.player_index]
 	local action = gui.read_action(event)
 	if action then
-        lobby.gui.on_gui_checked_state_changed(event, action, player)
+		lobby.gui.on_gui_checked_state_changed(event, action, player)
 		factions.gui.on_gui_checked_state_changed(event, action, player)
 	end
 end
@@ -163,10 +165,11 @@ gridworld.sync_faction = factions.sync_faction
 gridworld.open_faction_admin_screen = factions.open_faction_admin_screen
 gridworld.show_progress = util_gui.dialog_show_progress.draw
 gridworld.hmi_show_status = function()
-	factions.gui.dialog_faction_server_status.draw(game.get_player("Danielv123"), "pbnwcdal")
+	factions.gui.dialog_faction_server_status.draw(game.get_player("Danielv123"), get_player_faction(game.get_player("Danielv123")).faction_id)
 end
 gridworld.hmi_hide_status = function()
 	game.player.gui.left.clear()
 end
+gridworld.claim_server = claim_server
 
 return gridworld

--- a/module/lobby/gui/dialog_new_game/draw.lua
+++ b/module/lobby/gui/dialog_new_game/draw.lua
@@ -7,7 +7,7 @@ local function draw_new_game_dialog(player)
 	player.gui.center.clear()
 	gui.build(player.gui.center, {
 		{
-            type = "frame",
+			type = "frame",
 			name = "gridworld_new_game_dialog",
 			direction = "vertical",
 			ref = {"window"},

--- a/module/lobby/gui/dialog_new_game/draw.lua
+++ b/module/lobby/gui/dialog_new_game/draw.lua
@@ -7,7 +7,8 @@ local function draw_new_game_dialog(player)
 	player.gui.center.clear()
 	gui.build(player.gui.center, {
 		{
-			type = "frame",
+            type = "frame",
+			name = "gridworld_new_game_dialog",
 			direction = "vertical",
 			ref = {"window"},
 			-- Header

--- a/module/lobby/gui/dialog_new_game/events.lua
+++ b/module/lobby/gui/dialog_new_game/events.lua
@@ -11,7 +11,7 @@ local function on_gui_click(_, action, player)
 			name = faction.name,
 			open = faction.open,
 			owner = player.name,
-        })
+		})
 		-- Close window
 		local frame = player.gui.center["gridworld_new_game_dialog"]
 		if frame ~= nil then

--- a/module/lobby/gui/dialog_new_game/events.lua
+++ b/module/lobby/gui/dialog_new_game/events.lua
@@ -11,7 +11,12 @@ local function on_gui_click(_, action, player)
 			name = faction.name,
 			open = faction.open,
 			owner = player.name,
-		})
+        })
+		-- Close window
+		local frame = player.gui.center["gridworld_new_game_dialog"]
+		if frame ~= nil then
+			frame.destroy()
+		end
 	end
 	if action.location == "new_game_dialog" then
 		if action.action == "return_to_menu" then

--- a/module/lobby/gui/dialog_welcome/draw.lua
+++ b/module/lobby/gui/dialog_welcome/draw.lua
@@ -34,7 +34,7 @@ local function draw_welcome(player)
 						selected_tab_index = 1,
 					},
 					-- Welcome
-					get_tab_welcome(),
+					get_tab_welcome(player),
 					-- About gridworld
 					get_tab_about(),
 					-- Factions list

--- a/module/lobby/gui/dialog_welcome/tab_welcome.lua
+++ b/module/lobby/gui/dialog_welcome/tab_welcome.lua
@@ -1,4 +1,24 @@
-local function get_tab_welcome()
+local get_player_faction = require("modules/gridworld/faction/get_player_faction")
+
+local function get_tab_welcome(player)
+	local new_game_button = {
+		type = "button",
+		caption = "New game",
+		style = "button",
+		actions = {
+			on_click = {
+				action = "open_new_game_dialog",
+			},
+		},
+    }
+
+    -- Check if player is part of a faction
+    local player_faction = get_player_faction(player)
+    if player_faction ~= nil then
+		-- Don't allow the player to create a new game if they are part of a faction
+		new_game_button = {}
+	end
+
 	return {
 		tab = {
 			type = "tab",
@@ -44,16 +64,7 @@ local function get_tab_welcome()
 						},
 					},
 				},
-				{
-					type = "button",
-					caption = "New game",
-					style = "button",
-					actions = {
-						on_click = {
-							action = "open_new_game_dialog",
-						},
-					},
-				},
+				new_game_button,
 			},
 		}
 	}

--- a/module/lobby/gui/dialog_welcome/tab_welcome.lua
+++ b/module/lobby/gui/dialog_welcome/tab_welcome.lua
@@ -10,11 +10,11 @@ local function get_tab_welcome(player)
 				action = "open_new_game_dialog",
 			},
 		},
-    }
+	}
 
-    -- Check if player is part of a faction
-    local player_faction = get_player_faction(player)
-    if player_faction ~= nil then
+	-- Check if player is part of a faction
+	local player_faction = get_player_faction(player)
+	if player_faction ~= nil then
 		-- Don't allow the player to create a new game if they are part of a faction
 		new_game_button = {}
 	end

--- a/module/util/gui/show_progress/draw.lua
+++ b/module/util/gui/show_progress/draw.lua
@@ -49,6 +49,7 @@ local function draw_show_progress(player_name, header, text, progress, max_progr
 			-- Content
 			{
 				type = "flow",
+				direction = "vertical",
 				{
 					type = "progressbar",
 					value = progress / max_progress,

--- a/package.json
+++ b/package.json
@@ -1,48 +1,49 @@
 {
-  "name": "@danielv123/gridworld",
-  "version": "0.1.4",
-  "description": "Clusterio plugin for automatic creation of gridworlds connected using edge_transports",
-  "author": "Danielv <danielv@danielv.no>",
-  "homepage": "https://github.com/Danielv123/gridworld",
-  "license": "MIT",
-  "repository": "Danielv123/gridworld",
-  "scripts": {
-	"prepare": "webpack-cli --env production",
-	"lint": "eslint \"*.js\" src web --fix",
-	"luacheck": "luacheck module/",
-	"test": "npm run lint && npm run luacheck"
-  },
-  "bugs": {
-	"url": "https://github.com/Danielv123/gridworld/issues"
-  },
-  "engines": {
-	"node": ">=14"
-  },
-  "peerDependencies": {
-	"@clusterio/lib": "^2.0.0-alpha.0",
-	"react-router-dom": "*"
-  },
-  "dependencies": {
-	"@ant-design/icons": "^4.2.2",
-	"fs-extra": "^8.1.0",
-	"sharp": "^0.29.3"
-  },
-  "devDependencies": {
-	"@clusterio/web_ui": "^2.0.0-alpha.0",
-	"antd": "^4.16.0",
-	"eslint": "^8.4.1",
-	"eslint-plugin-node": "^11.1.0",
-	"leaflet": "^1.7.1",
-	"leaflet-rastercoords": "^1.0.4",
-	"react": "^16.13.1",
-	"react-dom": "^16.13.1",
-	"react-leaflet": "^2.8.0",
-	"react-leaflet-enhanced-marker": "^1.0.21",
-	"webpack": "^5.36.2",
-	"webpack-cli": "^4.7.0",
-	"webpack-merge": "^5.2.0"
-  },
-  "publishConfig": {
-	"access": "public"
-  }
+	"name": "@danielv123/gridworld",
+	"version": "0.1.4",
+	"description": "Clusterio plugin for automatic creation of gridworlds connected using edge_transports",
+	"author": "Danielv <danielv@danielv.no>",
+	"homepage": "https://github.com/Danielv123/gridworld",
+	"license": "MIT",
+	"repository": "Danielv123/gridworld",
+	"scripts": {
+		"prepare": "webpack-cli --env production && husky install",
+		"lint": "eslint \"*.js\" src web --fix",
+		"luacheck": "luacheck module/",
+		"test": "npm run lint && npm run luacheck"
+	},
+	"bugs": {
+		"url": "https://github.com/Danielv123/gridworld/issues"
+	},
+	"engines": {
+		"node": ">=14"
+	},
+	"peerDependencies": {
+		"@clusterio/lib": "^2.0.0-alpha.0",
+		"react-router-dom": "*"
+	},
+	"dependencies": {
+		"@ant-design/icons": "^4.2.2",
+		"fs-extra": "^8.1.0",
+		"sharp": "^0.29.3"
+	},
+	"devDependencies": {
+		"@clusterio/web_ui": "^2.0.0-alpha.0",
+		"antd": "^4.16.0",
+		"eslint": "^8.4.1",
+		"eslint-plugin-node": "^11.1.0",
+		"husky": "^8.0.1",
+		"leaflet": "^1.7.1",
+		"leaflet-rastercoords": "^1.0.4",
+		"react": "^16.13.1",
+		"react-dom": "^16.13.1",
+		"react-leaflet": "^2.8.0",
+		"react-leaflet-enhanced-marker": "^1.0.21",
+		"webpack": "^5.36.2",
+		"webpack-cli": "^4.7.0",
+		"webpack-merge": "^5.2.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"prepare": "webpack-cli --env production && husky install",
 		"lint": "eslint \"*.js\" src web --fix",
 		"luacheck": "luacheck module/",
-		"test": "spaces-to-tabs module/**/*.lua -s 4 && npm run lint && npm run luacheck"
+		"test": "spaces-to-tabs -s 4 module/**.lua module/**/**.lua module/**/**/**.lua module/**/**/**/**.lua module/**/**/**/**/**.lua && npm run lint && npm run luacheck"
 	},
 	"bugs": {
 		"url": "https://github.com/Danielv123/gridworld/issues"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"prepare": "webpack-cli --env production && husky install",
 		"lint": "eslint \"*.js\" src web --fix",
 		"luacheck": "luacheck module/",
-		"test": "npm run lint && npm run luacheck"
+		"test": "spaces-to-tabs module/**/*.lua -s 4 && npm run lint && npm run luacheck"
 	},
 	"bugs": {
 		"url": "https://github.com/Danielv123/gridworld/issues"
@@ -39,6 +39,7 @@
 		"react-dom": "^16.13.1",
 		"react-leaflet": "^2.8.0",
 		"react-leaflet-enhanced-marker": "^1.0.21",
+		"spaces-to-tabs": "^0.0.3",
 		"webpack": "^5.36.2",
 		"webpack-cli": "^4.7.0",
 		"webpack-merge": "^5.2.0"

--- a/src/event_handlers/playerPositionEventHandler.js
+++ b/src/event_handlers/playerPositionEventHandler.js
@@ -3,7 +3,7 @@ module.exports = async function playerPositionEventHandler(message) {
 	// Broadcast player position from instance to web interface
 	// TODO: Save position on master and broadcast full list on connect.
 	// TODO: Don't broadcast individual events unless position has changed.
-	for (let link of this.subscribedControlLinks) {
-		this.info.messages.playerPosition.send(link, message.data);
+	for (let sub of this.subscribedControlLinks) {
+		if (sub.player_posiiton) { this.info.messages.playerPosition.send(sub.link, message.data); }
 	}
 };

--- a/src/factions/faction_message_properties.js
+++ b/src/factions/faction_message_properties.js
@@ -12,6 +12,9 @@ const factionProperties = {
 				role: {
 					enum: ["leader", "officer", "member", "invited"],
 				},
+				promotion: {
+					enum: ["leader", "officer", "member", "invited", "null"],
+				},
 			},
 		},
 	},

--- a/src/factions/faction_message_properties.js
+++ b/src/factions/faction_message_properties.js
@@ -9,7 +9,7 @@ const factionProperties = {
 			type: "object",
 			properties: {
 				name: { type: "string" },
-				rank: {
+				role: {
 					enum: ["leader", "officer", "member", "invited"],
 				},
 			},

--- a/src/request_handlers/claimServerRequestHandler.js
+++ b/src/request_handlers/claimServerRequestHandler.js
@@ -1,0 +1,23 @@
+"use strict";
+
+module.exports = async function claimServerRequestHandler(message) {
+	// message.data = {
+	//  faction_id: "test",
+	//  player_name: "test",
+	//  instance_id: 1,
+	// };
+
+	// Check if the faction exists
+	const faction = this.factionsDatastore.get(message.data.faction_id);
+	if (!faction) {
+		return {
+			ok: false,
+			msg: "Faction does not exist",
+		};
+	}
+	this.setInstanceConfigField(message.data.instance_id, "gridworld.claimed_by_faction", message.data.faction_id);
+	return {
+		ok: true,
+		msg: "Server claimed",
+	};
+};

--- a/src/request_handlers/claimServerRequestHandler.js
+++ b/src/request_handlers/claimServerRequestHandler.js
@@ -12,12 +12,12 @@ module.exports = async function claimServerRequestHandler(message) {
 	if (!faction) {
 		return {
 			ok: false,
-			msg: "Faction does not exist",
+			message: "Faction does not exist",
 		};
 	}
 	this.setInstanceConfigField(message.data.instance_id, "gridworld.claimed_by_faction", message.data.faction_id);
 	return {
 		ok: true,
-		msg: "Server claimed",
+		message: "Server claimed",
 	};
 };

--- a/src/request_handlers/createFactionRequestHandler.js
+++ b/src/request_handlers/createFactionRequestHandler.js
@@ -6,6 +6,9 @@ module.exports = async function createFactionRequestHandler(message, request, li
 		open: message.data.open,
 		members: message.data.members,
 		about: message.data.about,
+		friends: message.data.friends || [],
+		enemies: message.data.enemies || [],
+		instances: message.data.instances || [],
 	};
 	this.factionsDatastore.set(message.data.faction_id, new_faction);
 	return {

--- a/src/request_handlers/createFactionRequestHandler.js
+++ b/src/request_handlers/createFactionRequestHandler.js
@@ -11,6 +11,15 @@ module.exports = async function createFactionRequestHandler(message, request, li
 		instances: message.data.instances || [],
 	};
 	this.factionsDatastore.set(message.data.faction_id, new_faction);
+
+	// Propagate changes to all online instances
+	this.broadcastEventToSlaves(this.info.messages.factionUpdate, { faction: new_faction });
+
+	// Propagate changes to listening web clients
+	for (let sub of this.subscribedControlLinks) {
+		if (sub.faction_list) { this.info.messages.factionUpdate.send(sub.link, { faction: new_faction }); }
+	}
+
 	return {
 		ok: true,
 		faction: new_faction,

--- a/src/request_handlers/factionChangeMemberRoleRequestHandler.js
+++ b/src/request_handlers/factionChangeMemberRoleRequestHandler.js
@@ -1,0 +1,35 @@
+"use strict";
+module.exports = async function factionChangeMemberRoleRequestHandler(message, request, link) {
+	const faction = this.factionsDatastore.get(message.data.faction_id);
+	if (faction) {
+		// Check that the player is in the faction
+		const member = faction.members.find(m => m.name.toLowerCase() === message.data.player_name.toLowerCase());
+		if (!member) {
+			return {
+				ok: false,
+				message: "Player is not in faction",
+			};
+		}
+
+		// Change the member role
+		const old_role = member.role;
+		member.role = message.data.role;
+
+		// Propagate changes to all online instances
+		this.broadcastEventToSlaves(this.info.messages.factionUpdate, { faction: faction });
+
+		// Propagate changes to listening web clients
+		for (let sub of this.subscribedControlLinks) {
+			if (sub.faction_list) { this.info.messages.factionUpdate.send(sub.link, { faction: faction }); }
+		}
+
+		return {
+			ok: true,
+			message: `Changed role of ${message.data.player_name} from ${old_role} to ${member.role} faction ${faction.name}`,
+		};
+	}
+	return {
+		ok: false,
+		message: "Faction not found",
+	};
+};

--- a/src/request_handlers/factionInvitePlayerRequestHandler.js
+++ b/src/request_handlers/factionInvitePlayerRequestHandler.js
@@ -1,0 +1,39 @@
+"use strict";
+module.exports = async function factionInvitePlayerRequestHandler(message, request, link) {
+	const faction = this.factionsDatastore.get(message.data.faction_id);
+	if (faction) {
+		// Check if the player is already in the faction
+		for (let member of faction.members) {
+			if (member.name === message.data.player_name) {
+				return {
+					ok: false,
+					message: "Player is already in the faction",
+				};
+			}
+		}
+
+		// Add the player to the faction
+		faction.members.push({
+			name: message.data.player_name,
+			role: "invited",
+			promotion: message.data.role,
+		});
+
+		// Propagate changes to all online instances
+		this.broadcastEventToSlaves(this.info.messages.factionUpdate, { faction: faction });
+
+		// Propagate changes to listening web clients
+		for (let sub of this.subscribedControlLinks) {
+			if (sub.faction_list) { this.info.messages.factionUpdate.send(sub.link, { faction: faction }); }
+		}
+
+		return {
+			ok: true,
+			message: `Invited ${message.data.player_name} to faction ${faction.name}`,
+		};
+	}
+	return {
+		ok: false,
+		message: "Faction not found",
+	};
+};

--- a/src/request_handlers/factionInvitePlayerRequestHandler.js
+++ b/src/request_handlers/factionInvitePlayerRequestHandler.js
@@ -4,7 +4,7 @@ module.exports = async function factionInvitePlayerRequestHandler(message, reque
 	if (faction) {
 		// Check if the player is already in the faction
 		for (let member of faction.members) {
-			if (member.name === message.data.player_name) {
+			if (member.name.toLowerCase() === message.data.player_name.toLowerCase()) {
 				return {
 					ok: false,
 					message: "Player is already in the faction",

--- a/src/request_handlers/joinFactionRequestHandler.js
+++ b/src/request_handlers/joinFactionRequestHandler.js
@@ -1,0 +1,73 @@
+"use strict";
+module.exports = async function joinFactionEventHandler(message) {
+	let player = message.data.player_name;
+	let faction_id = message.data.faction_id;
+
+	let faction = this.factionsDatastore.get(faction_id);
+	if (!faction) {
+		return {
+			ok: false,
+			message: "Faction not found",
+		};
+	}
+
+	// Check that the player is not already in the faction
+	let targetMember = faction.members.find(m => m.name.toLowerCase() === player.toLowerCase());
+	if (targetMember) {
+		return {
+			ok: false,
+			message: "Player is already in faction",
+		};
+	}
+
+	// Check if the player is allowed to join the faction
+	if (!faction.open) {
+		// Check if the player is invited
+		let member = faction.members.find(m => m.name.toLowerCase() === player.toLowerCase());
+		if (member.role !== "invited") {
+			return {
+				ok: false,
+				message: "Player is not invited to faction",
+			};
+		}
+	}
+
+	// Make player leave their old faction
+	for (let oldFaction of this.factionsDatastore.values()) {
+		let member = oldFaction.members.find(m => m.name.toLowerCase() === player.toLowerCase());
+		if (member) {
+			oldFaction.members.splice(oldFaction.members.indexOf(member), 1);
+			this.broadcastEventToSlaves(this.info.messages.factionUpdate, { faction: oldFaction });
+			for (let sub of this.subscribedControlLinks) {
+				if (sub.faction_list) { this.info.messages.factionUpdate.send(sub.link, { faction: oldFaction }); }
+			}
+		}
+	}
+
+	// Make player join new faction
+	if (targetMember && targetMember.role === "invited") {
+		targetMember.role = "member";
+		if (targetMember.promotion) {
+			targetMember.role = member.promotion;
+			targetMember.promotion = "member";
+		}
+	} else {
+		faction.members.push({
+			name: player,
+			role: "member",
+		});
+	}
+
+	// Propagate changes to all online instances
+	this.broadcastEventToSlaves(this.info.messages.factionUpdate, { faction: faction });
+
+	// Propagate changes to listening web clients
+	for (let sub of this.subscribedControlLinks) {
+		if (sub.faction_list) { this.info.messages.factionUpdate.send(sub.link, { faction: faction }); }
+	}
+
+	return {
+		ok: true,
+		message: `Player ${player} joined faction ${faction.name}`,
+	};
+};

--- a/src/request_handlers/joinGridworldRequestHandler.js
+++ b/src/request_handlers/joinGridworldRequestHandler.js
@@ -30,11 +30,11 @@ module.exports = async function joinGridworldRequestHandler(message, request, li
 		const instance_id = instance[1].config.get("instance.id");
 		const instance_stats = player.instanceStats.get(instance_id);
 		if (instance_stats
-			&& Math.max(instance_stats.lastJoinAt.getTime(), instance_stats.lastLeaveAt.getTime()) > (last_visited_instance_time || 0)
+			&& Math.max(instance_stats.lastJoinAt?.getTime() || 0, instance_stats.lastLeaveAt?.getTime() || 0) > (last_visited_instance_time || 0)
 			&& instance[1].config.get("gridworld.is_lobby_server") !== true
 		) {
 			last_visited_instance = instance[1];
-			last_visited_instance_time = Math.max(instance_stats.lastJoinAt.getTime(), instance_stats.lastLeaveAt.getTime());
+			last_visited_instance_time = Math.max(instance_stats.lastJoinAt?.getTime() || 0, instance_stats.lastLeaveAt?.getTime() || 0);
 		}
 	}
 	if (last_visited_instance) {

--- a/src/request_handlers/joinGridworldRequestHandler.js
+++ b/src/request_handlers/joinGridworldRequestHandler.js
@@ -13,7 +13,7 @@ module.exports = async function joinGridworldRequestHandler(message, request, li
 	const player = this.master.userManager.users.get(player_name);
 
 	// Get player faction
-	const faction = mapFind(this.factionsDatastore, f => f.members.find(member => member.name === player_name));
+	const faction = mapFind(this.factionsDatastore, f => f.members.find(member => member.name.toLowerCase() === player_name.toLowerCase()));
 
 	// Get all instances in the current grid
 	const instances = mapFilter(this.master.instances, instance => instance.config.get("gridworld.grid_id") === message.data.grid_id);

--- a/src/request_handlers/leaveFactionRequestHandler.js
+++ b/src/request_handlers/leaveFactionRequestHandler.js
@@ -1,0 +1,25 @@
+"use strict";
+module.exports = async function leaveFactionRequestHandler(message, request, link) {
+	const faction = this.factionsDatastore.get(message.data.faction_id);
+	if (faction) {
+		// Remove the player from the faction
+		faction.members = faction.members.filter(member => member.name.toLowerCase() !== message.data.player_name.toLowerCase());
+
+		// Propagate changes to all online instances
+		this.broadcastEventToSlaves(this.info.messages.factionUpdate, { faction: faction });
+
+		// Propagate changes to listening web clients
+		for (let sub of this.subscribedControlLinks) {
+			if (sub.faction_list) { this.info.messages.factionUpdate.send(sub.link, { faction: faction }); }
+		}
+
+		return {
+			ok: true,
+			message: `Removed ${message.data.player_name} from faction ${faction.name}`,
+		};
+	}
+	return {
+		ok: false,
+		message: "Faction not found",
+	};
+};

--- a/src/request_handlers/performEdgeTeleportRequestHandler.js
+++ b/src/request_handlers/performEdgeTeleportRequestHandler.js
@@ -23,7 +23,7 @@ module.exports = async function joinGridworldRequestHandler(message) {
 
 	// Get player faction
 	// TODO: Sync faction data to destination instance
-	// const faction = mapFind(this.factionsDatastore, f => f.members.find(member => member.name === player_name));
+	// const faction = mapFind(this.factionsDatastore, f => f.members.find(member => member.name.toLowerCase() === player_name.toLowerCase));
 
 	// Get the destination instance
 	const instance_specification = worldPositionToInstance(

--- a/src/request_handlers/refreshFactionDataRequestHandler.js
+++ b/src/request_handlers/refreshFactionDataRequestHandler.js
@@ -1,0 +1,19 @@
+"use strict";
+//
+// Refresh faction data for factions that have changed since the last time the instance was online.
+// TODO: Implement delta updates rather than sending all data every time.
+//
+module.exports = async function refreshFactionDataRequestHandler(message, request, link) {
+	const updatedFactions = [];
+
+	// Get updated factions
+	for (let faction of this.factionsDatastore.values()) {
+		updatedFactions.push(faction);
+	}
+
+	return {
+		ok: true,
+		message: "Faction data refreshed",
+		factions: updatedFactions,
+	};
+};

--- a/src/request_handlers/refreshFactionDataRequestHandler.js
+++ b/src/request_handlers/refreshFactionDataRequestHandler.js
@@ -13,7 +13,7 @@ module.exports = async function refreshFactionDataRequestHandler(message, reques
 
 	return {
 		ok: true,
-		message: "Faction data refreshed",
+		msg: "Faction data refreshed",
 		factions: updatedFactions,
 	};
 };

--- a/src/request_handlers/refreshFactionDataRequestHandler.js
+++ b/src/request_handlers/refreshFactionDataRequestHandler.js
@@ -13,7 +13,7 @@ module.exports = async function refreshFactionDataRequestHandler(message, reques
 
 	return {
 		ok: true,
-		msg: "Faction data refreshed",
+		message: "Faction data refreshed",
 		factions: updatedFactions,
 	};
 };

--- a/src/request_handlers/setPlayerPositionSubscriptionRequestHandler.js
+++ b/src/request_handlers/setPlayerPositionSubscriptionRequestHandler.js
@@ -1,8 +1,0 @@
-"use strict";
-module.exports = async function setPlayerPositionSubscriptionRequestHandler(message, request, link) {
-	if (message.data.player_position) {
-		this.subscribedControlLinks.add(link);
-	} else {
-		this.subscribedControlLinks.delete(link);
-	}
-};

--- a/src/request_handlers/setWebSubscriptionRequestHandler.js
+++ b/src/request_handlers/setWebSubscriptionRequestHandler.js
@@ -1,0 +1,47 @@
+"use strict";
+
+async function transmitInitialFactionsData(master, link) {
+	// Transmit a full copy of the data to the new client
+	for (let [id, faction] of master.factionsDatastore) {
+		await master.info.messages.factionUpdate.send(link, { faction });
+	}
+}
+
+async function transmitInitialPlayerPositionsData(master, link) {
+	// Transmit a full copy of the data to the new client
+	// for (let [id, player] of master.gridworldDatastore) {
+	//  await master.info.messages.playerPositionUpdate.send(link, { player });
+	// }
+}
+
+module.exports = async function setWebSubscriptionRequestHandler(message, request, link) {
+	let existingLink = this.subscribedControlLinks.find((sub) => sub.link === link);
+	if (message.data.player_position || message.data.faction_list) {
+		// Check if this link is already subscribed
+		if (existingLink) {
+			// Transmit initial data if the client is newly subscribing to this data
+			if (message.data.player_position && !existingLink.player_position) {
+				await transmitInitialPlayerPositionsData(this, link);
+			}
+			if (message.data.faction_list && !existingLink.faction_list) {
+				await transmitInitialFactionsData(this, link);
+			}
+
+			// Update existing subscription
+			existingLink.player_position = message.data.player_position;
+			existingLink.faction_list = message.data.faction_list;
+		} else {
+			// Add new subscription
+			await transmitInitialPlayerPositionsData(this, link);
+			await transmitInitialFactionsData(this, link);
+			this.subscribedControlLinks.push({
+				link,
+				player_position: message.data.player_position,
+				faction_list: message.data.faction_list,
+			});
+		}
+	} else {
+		// Remove existing subscription
+		this.subscribedControlLinks.splice(this.subscribedControlLinks.indexOf(existingLink), 1);
+	}
+};

--- a/src/request_handlers/unclaimServerRequestHandler.js
+++ b/src/request_handlers/unclaimServerRequestHandler.js
@@ -10,6 +10,6 @@ module.exports = async function unclaimServerRequestHandler(message) {
 	this.setInstanceConfigField(message.data.instance_id, "gridworld.claimed_by_faction", "-");
 	return {
 		ok: true,
-		msg: "Server unclaimed",
+		message: "Server unclaimed",
 	};
 };

--- a/src/request_handlers/unclaimServerRequestHandler.js
+++ b/src/request_handlers/unclaimServerRequestHandler.js
@@ -1,0 +1,15 @@
+"use strict";
+
+module.exports = async function unclaimServerRequestHandler(message) {
+	// message.data = {
+	//  faction_id: "test",
+	//  player_name: "test",
+	//  instance_id: 1,
+	// };
+
+	this.setInstanceConfigField(message.data.instance_id, "gridworld.claimed_by_faction", "-");
+	return {
+		ok: true,
+		msg: "Server unclaimed",
+	};
+};

--- a/src/request_handlers/updateFactionRequestHandler.js
+++ b/src/request_handlers/updateFactionRequestHandler.js
@@ -10,6 +10,11 @@ module.exports = async function updateFactionRequestHandler(message, request, li
 		// Propagate changes to all online instances
 		this.broadcastEventToSlaves(this.info.messages.factionUpdate, { faction: faction });
 
+		// Propagate changes to listening web clients
+		for (let sub of this.subscribedControlLinks) {
+			if (sub.faction_list) { this.info.messages.factionUpdate.send(sub.link, { faction: faction }); }
+		}
+
 		return {
 			ok: true,
 			message: "Faction updated",

--- a/web/pages/FactionViewPage.jsx
+++ b/web/pages/FactionViewPage.jsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useContext, useState } from "react";
+import { useParams } from "react-router-dom";
+import { Alert, Descriptions, Spin, Table, PageHeader } from "antd";
+
+import { ControlContext, PageLayout } from "@clusterio/web_ui";
+import useFactionList from "../providers/useFactionList";
+
+export default function FactionViewPage() {
+	const params = useParams();
+	const control = useContext(ControlContext);
+	const factions = useFactionList(control);
+	const faction = factions.find(f => f.faction_id === params.faction_id);
+
+	const factionName = faction?.name ?? "Unknown Faction";
+	let nav = [{ name: "Factions", path: "/gridworld/factions" }, { name: factionName }];
+	if (!factions) {
+		return <PageLayout nav={nav}>
+			<Descriptions borderd size="small" title={factionName} />
+			<Spin size="large" />
+		</PageLayout>;
+	}
+
+	if (!faction) {
+		return <PageLayout nav={nav}>
+			<Descriptions bordered size="small" title={factionName}>
+				<Descriptions.Item label="Faction ID">{params.faction_id}</Descriptions.Item>
+			</Descriptions>
+			<Alert
+				style={{
+					marginTop: "1em",
+				}}
+				message={"Error loading faction"}
+				description={
+					"The web interface was unable to load the faction. This is " +
+					"usually due to an incorrect faction ID or a missing faction."
+				}
+				type="error"
+				showIcon
+			/>
+		</PageLayout>;
+	}
+
+	return <PageLayout nav={nav}>
+		<PageHeader
+			className="site-page-header"
+			title={factionName}
+			subTitle={faction.about.header}
+		/>
+		<Descriptions bordered size="small">
+			<Descriptions.Item label="ID">{params.faction_id}</Descriptions.Item>
+			<Descriptions.Item label="Open" span={2}>{faction.open ? "Yes" : "No"}</Descriptions.Item>
+			<Descriptions.Item label="Header" span={3}>{faction.about.header}</Descriptions.Item>
+			<Descriptions.Item label="Description" span={3}>{faction.about.description}</Descriptions.Item>
+			<Descriptions.Item label="Rules" span={3}>{faction.about.rules}</Descriptions.Item>
+		</Descriptions>
+		<PageHeader
+			className="site-page-header"
+			title="Members"
+		/>
+		<Table
+			columns={[
+				{
+					title: "Name",
+					key: "name",
+					dataIndex: "name",
+				},
+				{
+					title: "Role",
+					key: "role",
+					dataIndex: "role",
+				},
+			]}
+			dataSource={faction.members}
+			rowKey="name"
+		/>
+		<PageHeader
+			className="site-page-header"
+			title="Friends"
+		/>
+		<Table
+			columns={[
+				{
+					title: "Name",
+					key: "name",
+					dataIndex: "name",
+				},
+			]}
+			dataSource={faction.friends}
+			rowKey="name"
+		/>
+		<PageHeader
+			className="site-page-header"
+			title="Enemies"
+		/>
+		<Table
+			columns={[
+				{
+					title: "Name",
+					key: "name",
+					dataIndex: "name",
+				},
+			]}
+			dataSource={faction.enemies}
+			rowKey="name"
+		/>
+		<PageHeader
+			className="site-page-header"
+			title="Instances"
+		/>
+		<Table
+			columns={[
+				{
+					title: "Name",
+					key: "name",
+					dataIndex: "name",
+				},
+				{
+					title: "ID",
+					key: "instance_id",
+					dataIndex: "instance_id",
+				},
+			]}
+			dataSource={faction.instances}
+			rowKey="instance_id"
+		/>
+	</PageLayout>;
+}

--- a/web/pages/FactionsPage.jsx
+++ b/web/pages/FactionsPage.jsx
@@ -1,0 +1,68 @@
+import React, { useContext } from "react";
+import { useHistory } from "react-router-dom";
+import { Button, PageHeader, Popconfirm, Table } from "antd";
+import DeleteOutlined from "@ant-design/icons/DeleteOutlined";
+
+import "../index.css";
+import { libLink } from "@clusterio/lib";
+import { ControlContext, PageLayout, useAccount, notifyErrorHandler } from "@clusterio/web_ui";
+import useFactionList from "../providers/useFactionList";
+
+function FactionsPage() {
+	const control = useContext(ControlContext);
+	const history = useHistory();
+	const factions = useFactionList(control);
+	let account = useAccount();
+
+	return <PageLayout nav={[{ name: "Gridworld" }]}>
+		<PageHeader
+			className="site-page-header"
+			title="Factions"
+			extra={[
+				account.hasPermission("gridworld.faction.delete")
+				&& <Popconfirm
+					key="delete"
+					title="Permanently delete ALL factions?"
+					okText="Delete"
+					placement="bottomRight"
+					okButtonProps={{ danger: true }}
+					onConfirm={async () => {
+						for (let faction of factions) {
+							// TODO: Delete faction
+						}
+					}}
+				>
+					<Button danger>
+						<DeleteOutlined />
+					</Button>
+				</Popconfirm>,
+			]}
+		/>
+		<p>List of active factions in the gridworld</p>
+		<Table
+			columns={[
+				{
+					title: "Name",
+					key: "name",
+					render: faction => faction.name,
+					defaultSortOrder: "ascend",
+					sorter: (a, b) => a.name.localeCompare(b.name),
+				},
+				{
+					title: "Members",
+					key: "members",
+					render: (_, faction) => faction.members.length,
+				},
+			]}
+			dataSource={factions}
+			rowKey="faction_id"
+			onRow={faction => ({
+				onClick: event => {
+					history.push(`/gridworld/factions/${faction.faction_id}/view`);
+				},
+			})}
+		/>
+	</PageLayout>;
+}
+
+export default FactionsPage;

--- a/web/providers/useFactionList.jsx
+++ b/web/providers/useFactionList.jsx
@@ -1,0 +1,23 @@
+import React, { useEffect, useState } from "react";
+
+export default function useFactionList(control) {
+	let plugin = control.plugins.get("gridworld");
+	let [factions, setFactions] = useState([...plugin.factions]);
+
+	useEffect(() => {
+		function update(faction) {
+			plugin.factions.set(faction.faction_id, faction);
+			setFactions([...plugin.factions]);
+		}
+
+		const updateHandler = {
+			callback: update,
+			type: "faction_list",
+		};
+		plugin.onUpdate(updateHandler);
+		return () => {
+			plugin.offUpdate(updateHandler);
+		};
+	}, []);
+	return factions.map(x => x[1]);
+}

--- a/web/providers/userPlayerPosition.jsx
+++ b/web/providers/userPlayerPosition.jsx
@@ -5,13 +5,18 @@ export default function usePlayerPosition(control) {
 	let [playerPositions, setPlayerPositions] = useState([...plugin.playerPositions]);
 
 	useEffect(() => {
-		function update() {
+		function update(player) {
+			plugin.playerPositions.set(player.player_name, player);
 			setPlayerPositions([...plugin.playerPositions]);
 		}
 
-		plugin.onUpdate(update);
+		const updateHandler = {
+			callback: update,
+			type: "player_position",
+		};
+		plugin.onUpdate(updateHandler);
 		return () => {
-			plugin.offUpdate(update);
+			plugin.offUpdate(updateHandler);
 		};
 	}, []);
 	return playerPositions;


### PR DESCRIPTION
Adds faction support to the grid instances

- [x] Synching faction data
- [x] Claiming servers
- [x] Unclaiming servers
- [x] Inviting players to factions
- [x] accepting invites
- [ ] Building permissions on claimed servers
- [x] Don't allow players to create a new faction without leaving their current
- [x] Ability to leave your faction
- [x] Don't allow players to join a new faction without leaving their current
- [x] Web interface for factions

along with some misc tooling changes.