### PR TITLE
Use base auto ports

### DIFF
--- a/src/request_handlers/joinGridworldRequestHandler.js
+++ b/src/request_handlers/joinGridworldRequestHandler.js
@@ -91,7 +91,7 @@ module.exports = async function joinGridworldRequestHandler(message, request, li
 		}
 
 		const host = this.controller.hosts.get(hostId);
-		response.connection_address = `${host.publicAddress}:${instance_to_connect_to.game_port || instance_to_connect_to.config.get("factorio.game_port")}`;
+		response.connection_address = `${host.publicAddress}:${instance_to_connect_to.gamePort || instance_to_connect_to.config.get("factorio.game_port")}`;
 	}
 
 	// Return response to client

--- a/src/request_handlers/performEdgeTeleportRequestHandler.js
+++ b/src/request_handlers/performEdgeTeleportRequestHandler.js
@@ -77,7 +77,6 @@ module.exports = async function joinGridworldRequestHandler(message) {
 	// Ensure the instance we are connecting to is started
 	if (instance_to_connect_to) {
 		const hostId = instance_to_connect_to.config.get("instance.assigned_host");
-		let hostConnection = this.controller.wsServer.hostConnections.get(hostId);
 		// Instance status
 		if (instance_to_connect_to.status !== "running") {
 			try {
@@ -96,7 +95,7 @@ module.exports = async function joinGridworldRequestHandler(message) {
 		}
 
 		const host = this.controller.hosts.get(hostId);
-		response.connection_address = `${host.publicAddress}:${instance_to_connect_to.game_port || instance_to_connect_to.config.get("factorio.game_port")}`;
+		response.connection_address = `${host.publicAddress}:${instance_to_connect_to.gamePort || instance_to_connect_to.config.get("factorio.game_port")}`;
 	}
 
 	// Return response to client

--- a/src/request_handlers/updateEdgeTransportEdgesRequestHandler.js
+++ b/src/request_handlers/updateEdgeTransportEdgesRequestHandler.js
@@ -2,16 +2,7 @@
 
 const mapFind = require("../util/mapFind");
 const getEdges = require("../worldgen/getEdges");
-
-// Grid coordinate offsets, X,Y pair where negative is north/west
-// Offset is used to get from the destination back to the origin, using edge id from origin edge as index
-const edge_target_position_offets = [
-	{},
-	[0, -1], // North, when walking south
-	[1, 0], // East, when walking west
-	[0, 1], // South, when walking north
-	[-1, 0], // West, when walking east
-];
+const { edge_target_position_offsets } = require("../worldgen/factionGrid/edge_target_position_offsets");
 
 module.exports = async function updateEdgeTransportsEdges(message) {
 	// message.data === {
@@ -42,8 +33,8 @@ module.exports = async function updateEdgeTransportsEdges(message) {
 	// Find neighboring instances and update edge target instance ID
 	for (const edge of edges) {
 		const target_position = [
-			x + edge_target_position_offets[edge.id][0],
-			y + edge_target_position_offets[edge.id][1],
+			x + edge_target_position_offsets[edge.id][0],
+			y + edge_target_position_offsets[edge.id][1],
 		];
 		const target_instance = this.controller.instances.get(edge.target_instance);
 		if (

--- a/src/util/hostGetNextFreePort.js
+++ b/src/util/hostGetNextFreePort.js
@@ -9,7 +9,7 @@ module.exports = function hostGetNextFreePort(controller, host_id) {
 	// Find next free port
 	let port = lowestPort;
 	function portIsInUse() {
-		return mapFind(instances, instance => instance.game_port === port || instance.config.get("factorio.game_port") === port);
+		return mapFind(instances, instance => instance.gamePort === port || instance.config.get("factorio.game_port") === port);
 	}
 	while (portIsInUse()) {
 		port += 1;

--- a/src/worldgen/createInstance.js
+++ b/src/worldgen/createInstance.js
@@ -2,7 +2,7 @@
 const { InstanceInfo } = require("@clusterio/controller");
 const lib = require("@clusterio/lib");
 
-module.exports = async function createInstance(plugin, name, x, y, x_size, y_size, grid_id, game_port) {
+module.exports = async function createInstance(plugin, name, x, y, x_size, y_size, grid_id, game_port = undefined) {
 	plugin.logger.info("Creating instance", name);
 	let instanceConfig = new lib.InstanceConfig("controller");
 	instanceConfig.set("instance.name", name);

--- a/src/worldgen/createLobbyServer.js
+++ b/src/worldgen/createLobbyServer.js
@@ -15,7 +15,7 @@ module.exports = async function createLobbyServer(plugin, hostId, x_size, y_size
 	instanceConfig.set("gridworld.grid_id", Math.ceil(Math.random() * 1000));
 	instanceConfig.set("gridworld.grid_x_size", x_size);
 	instanceConfig.set("gridworld.grid_y_size", y_size);
-	instanceConfig.set("factorio.game_port", 10000);
+	// instanceConfig.set("factorio.game_port", 10000); // Use clusterio port assignment
 	lib.logger.info("Created config");
 	let instanceId = instanceConfig.get("instance.id");
 	if (plugin.controller.instances.has(instanceId)) {

--- a/src/worldgen/factionGrid/createServer.js
+++ b/src/worldgen/factionGrid/createServer.js
@@ -7,7 +7,6 @@ const getEdges = require("../getEdges");
 const packagejson = require("../../../package.json");
 const mapFind = require("../../util/mapFind");
 const mapFilter = require("../../util/mapFilter");
-const hostGetNextFreePort = require("../../util/hostGetNextFreePort");
 
 module.exports = async function createServer({
 	plugin,
@@ -41,8 +40,7 @@ module.exports = async function createServer({
 	}
 
 	// Create instance
-	const instance_game_port = hostGetNextFreePort(plugin.controller, hostId);
-	const instanceId = await createInstance(plugin, `Grid square ${Math.floor(Math.random() * 2 ** 16).toString()}`, x, y, x_size, y_size, grid_id, instance_game_port);
+	const instanceId = await createInstance(plugin, `Grid square ${Math.floor(Math.random() * 2 ** 16).toString()}`, x, y, x_size, y_size, grid_id);
 
 	// Assign instance to host
 	await assignInstance(plugin, instanceId, hostId);

--- a/src/worldgen/factionGrid/edge_target_position_offsets.js
+++ b/src/worldgen/factionGrid/edge_target_position_offsets.js
@@ -1,0 +1,11 @@
+"use strict";
+// Grid coordinate offsets, X,Y pair where negative is north/west
+// Offset is used to get from the destination back to the origin, using edge id from origin edge as index
+const edge_target_position_offsets = [
+	{},
+	[0, -1], // North, when walking south
+	[1, 0], // East, when walking west
+	[0, 1], // South, when walking north
+	[-1, 0], // West, when walking east
+];
+exports.edge_target_position_offsets = edge_target_position_offsets;

--- a/src/worldgen/getEdges.js
+++ b/src/worldgen/getEdges.js
@@ -9,6 +9,7 @@ module.exports = function getEdges({
 	y,
 	instances,
 	grid_id,
+	includeMissing = false,
 }) {
 	const worldfactor_x = (x - 1) * x_size;
 	const worldfactor_y = (y - 1) * y_size;
@@ -66,5 +67,8 @@ module.exports = function getEdges({
 		)?.config.get("instance.id") || 0,
 		target_edge: 2,
 	});
+	if (includeMissing) {
+		return edges;
+	}
 	return edges.filter(edge => edge.target_instance !== 0);
 };

--- a/src/worldgen/util/worldPositionToInstance.js
+++ b/src/worldgen/util/worldPositionToInstance.js
@@ -20,6 +20,8 @@ function worldPositionToInstance(x, y, grid_id, instances) {
 	return {
 		x,
 		y,
+		grid_x_size,
+		grid_y_size,
 		grid_x_position,
 		grid_y_position,
 		instance: mapFind(grid_instances, instance => instance.config.get("gridworld.grid_x_position") === grid_x_position


### PR DESCRIPTION
When the gridworld plugin was first created, clusterio did not have a way to automatically assign instance ports. This meant that for every new instance created, a port had to be manually assigned in the web interface. I solved this by implementing automatic port picking in gridworld.

Clusterio now supports automatic port assignment, so this feature is no longer needed. This plugin changes to use the default clusterio port assignment and correctly read the assigned port.