### PR TITLE
Improve map entity rendering

### DIFF
--- a/instance.js
+++ b/instance.js
@@ -117,7 +117,7 @@ class InstancePlugin extends BaseInstancePlugin {
 			// Update neighboring nodes for edge_transports
 			await sleep(1000);
 			await this.instance.sendTo("controller", new messages.UpdateEdgeTransportEdges({
-				instance_id: this.instance.id,
+				instance_id: this.instance.config.get("instance.id"),
 			}));
 			// Refresh faction data
 			const response = await this.instance.sendTo("controller", new messages.RefreshFactionData());

--- a/instance.js
+++ b/instance.js
@@ -104,6 +104,7 @@ class InstancePlugin extends BaseInstancePlugin {
 			world_x: this.instance.config.get("gridworld.grid_x_position"),
 			world_y: this.instance.config.get("gridworld.grid_y_position"),
 		};
+		await this.sendRcon("/sc gridworld.is_server_unsafe_desync = true");
 		if (this.instance.config.get("gridworld.is_lobby_server")) {
 			await this.sendRcon("/sc gridworld.register_lobby_server(true)");
 			// Get gridworld data
@@ -128,7 +129,7 @@ class InstancePlugin extends BaseInstancePlugin {
 			const x = data.world_x * data.x_size;
 			const y = data.world_y * data.y_size;
 			await this.sendRcon(`/sc gridworld.map.dump_mapview({${x - data.x_size},${y - data.y_size}}, {${x},${y}})`);
-			await this.sendRcon(`/c gridworld.map.dump_entities(game.surfaces[1].find_entities_filtered{area = {{${x - data.x_size},${y - data.y_size}}, {${x},${y}}}})`);
+			await this.sendRcon(`/sc gridworld.map.dump_entities(game.surfaces[1].find_entities_filtered{area = {{${x - data.x_size},${y - data.y_size}}, {${x},${y}}}})`);
 		}
 	}
 

--- a/messages.js
+++ b/messages.js
@@ -588,8 +588,9 @@ module.exports = {
 		static plugin = pluginName;
 		static jsonSchema = {
 			type: "object",
-			required: ["type", "data"],
+			required: ["type", "data", "instance_id", "grid_id"],
 			properties: {
+				grid_id: { type: "integer" },
 				type: {
 					type: "string", enum: [
 						"tiles", // array of pixels for a 32x32 chunk with lines starting horizontally from the top
@@ -602,18 +603,21 @@ module.exports = {
 					type: "array",
 					items: { type: "string" },
 				},
+				instance_id: { type: "integer" },
 				layer: { type: "string" }, // optional, defaults to "" for entities
 			},
 		};
-		constructor(type, data, position, size, layer = "") {
+		constructor(type, data, position, size, instance_id, grid_id, layer = "") {
 			this.type = type;
 			this.data = data;
 			this.position = position;
 			this.size = size;
+			this.instance_id = instance_id;
+			this.grid_id = grid_id;
 			this.layer = layer;
 		}
 		static fromJSON(json) {
-			return new this(json.type, json.data, json.position, json.size, json.layer);
+			return new this(json.type, json.data, json.position, json.size, json.instance_id, json.grid_id, json.layer);
 		}
 	},
 	RefreshTileData: class RefreshTileData {

--- a/messages.js
+++ b/messages.js
@@ -602,16 +602,18 @@ module.exports = {
 					type: "array",
 					items: { type: "string" },
 				},
+				layer: { type: "string" }, // optional, defaults to "" for entities
 			},
 		};
-		constructor(type, data, position, size) {
+		constructor(type, data, position, size, layer = "") {
 			this.type = type;
 			this.data = data;
 			this.position = position;
 			this.size = size;
+			this.layer = layer;
 		}
 		static fromJSON(json) {
-			return new this(json.type, json.data, json.position, json.size);
+			return new this(json.type, json.data, json.position, json.size, json.layer);
 		}
 	},
 	RefreshTileData: class RefreshTileData {

--- a/module/gridworld.lua
+++ b/module/gridworld.lua
@@ -239,6 +239,7 @@ end
 gridworld.events[defines.events.on_chunk_generated] = function(event)
 	if not global.gridworld.lobby_server then
 		worldgen.events.on_chunk_generated(event)
+		map.events.on_chunk_generated(event)
 	end
 end
 gridworld.events[defines.events.on_tick] = function(event)

--- a/module/gridworld.lua
+++ b/module/gridworld.lua
@@ -66,7 +66,11 @@ gridworld.events[clusterio_api.events.on_server_startup] = function()
 		global.gridworld.map = {
 			added_entities_to_update = nil,
 			removed_entities_to_update = nil,
+			entity_registrations = {},
 		}
+	end
+	if global.gridworld.map.entity_registrations == nil then
+		global.gridworld.map.entity_registrations = {}
 	end
 
 	-- Fun factions inititalization
@@ -133,6 +137,14 @@ gridworld.events[defines.events.on_built_entity] = function(event)
 		end
 	end
 end
+gridworld.events[defines.events.on_biter_base_built] = function(event)
+	if not global.gridworld.lobby_server then
+		local entity = event.entity
+		if entity.valid then
+			map.events.on_biter_base_built(event, entity)
+		end
+	end
+end
 gridworld.events[defines.events.on_entity_cloned] = function(event)
 	if not global.gridworld.lobby_server then
 		local entity = event.destination
@@ -175,6 +187,27 @@ gridworld.events[defines.events.on_entity_destroyed] = function(event)
 		-- Instead, use the registration_number stored previously.
 		map.events.on_entity_destroyed(event) -- Run before load balancing to hijack its event registrations
 		load_balancing.events.on_entity_destroyed(event)
+	end
+end
+-- "Soft" entity removal events, used for cleanup of things we havent registered
+gridworld.events[defines.events.on_player_mined_entity] = function(event)
+	if not global.gridworld.lobby_server then
+		map.events.on_player_mined_entity(event)
+	end
+end
+gridworld.events[defines.events.on_robot_mined_entity] = function(event)
+	if not global.gridworld.lobby_server then
+		map.events.on_robot_mined_entity(event)
+	end
+end
+gridworld.events[defines.events.on_entity_died] = function(event)
+	if not global.gridworld.lobby_server then
+		map.events.on_entity_died(event)
+	end
+end
+gridworld.events[defines.events.on_pre_robot_exploded_cliff] = function(event)
+	if not global.gridworld.lobby_server then
+		map.events.on_pre_robot_exploded_cliff(event)
 	end
 end
 gridworld.events[defines.events.on_gui_click] = function(event)

--- a/module/gridworld.lua
+++ b/module/gridworld.lua
@@ -67,6 +67,7 @@ gridworld.events[clusterio_api.events.on_server_startup] = function()
 			added_entities_to_update = nil,
 			removed_entities_to_update = nil,
 			entity_registrations = {},
+			tiles_to_update = nil,
 		}
 	end
 	if global.gridworld.map.entity_registrations == nil then
@@ -245,6 +246,31 @@ end
 gridworld.events[defines.events.on_tick] = function(event)
 	if not global.gridworld.lobby_server then
 		worldgen.events.on_tick(event)
+	end
+end
+gridworld.events[defines.events.on_player_built_tile] = function(event)
+	if not global.gridworld.lobby_server then
+		map.events.on_player_built_tile(event)
+	end
+end
+gridworld.events[defines.events.on_robot_built_tile] = function(event)
+	if not global.gridworld.lobby_server then
+		map.events.on_robot_built_tile(event)
+	end
+end
+gridworld.events[defines.events.on_player_mined_tile] = function(event)
+	if not global.gridworld.lobby_server then
+		map.events.on_player_mined_tile(event)
+	end
+end
+gridworld.events[defines.events.on_robot_mined_tile] = function(event)
+	if not global.gridworld.lobby_server then
+		map.events.on_robot_mined_tile(event)
+	end
+end
+gridworld.events[defines.events.script_raised_set_tiles] = function(event)
+	if not global.gridworld.lobby_server then
+		map.events.script_raised_set_tiles(event)
 	end
 end
 gridworld.on_nth_tick = {}

--- a/module/map/dump_entities.lua
+++ b/module/map/dump_entities.lua
@@ -34,7 +34,12 @@ local function dump_entities(entities)
 						-- Format as hexadecimal
 						table.insert(map_data, position.x + x - (size_x-1)/2)
 						table.insert(map_data, position.y + y - (size_y-1)/2)
+						if entity.type == "entity-ghost" then
+							-- Render as purple
+							table.insert(map_data, "A800A8")
+						else
 						table.insert(map_data, string.format("%02x%02x%02x", map_color.r, map_color.g, map_color.b))
+						end
 					end
 				end
 			end

--- a/module/map/dump_entities.lua
+++ b/module/map/dump_entities.lua
@@ -16,17 +16,27 @@ local function dump_entities(entities)
 		if map_color ~= nil then
 			local is_resource = entity.prototype.collision_mask["resource-layer"]
 			if is_resource then
-				if (math.floor(position.x/2) + math.floor(position.y/2)) % 2 == 0 then
 				-- Create checkerboard pattern associated with resources
-				table.insert(map_data, position.x)
-				table.insert(map_data, position.y)
-				table.insert(map_data, string.format("%02x%02x%02x", map_color.r, map_color.g, map_color.b))
+				if (math.floor(position.x/2) + math.floor(position.y/2)) % 2 == 0 then
+					table.insert(map_data, position.x)
+					table.insert(map_data, position.y)
+					table.insert(map_data, string.format("%02x%02x%02x", map_color.r, map_color.g, map_color.b))
 				end
 			else
-				-- Format as hexadecimal
-				table.insert(map_data, position.x)
-				table.insert(map_data, position.y)
-				table.insert(map_data, string.format("%02x%02x%02x", map_color.r, map_color.g, map_color.b))
+				-- Determine size of entity to draw
+				-- TODO: Does not seem to get the correct shape for trees and cliffs
+				local size_x = math.ceil((entity.bounding_box.left_top.x - entity.bounding_box.right_bottom.x) * -1)
+				local size_y = math.ceil((entity.bounding_box.left_top.y - entity.bounding_box.right_bottom.y) * -1)
+
+				-- Add pixels
+				for x = 0, size_x-1 do
+					for y = 0, size_y-1 do
+						-- Format as hexadecimal
+						table.insert(map_data, position.x + x - (size_x-1)/2)
+						table.insert(map_data, position.y + y - (size_y-1)/2)
+						table.insert(map_data, string.format("%02x%02x%02x", map_color.r, map_color.g, map_color.b))
+					end
+				end
 			end
 		end
 		::continue::
@@ -37,7 +47,7 @@ local function dump_entities(entities)
 		data = table.concat(map_data, ";"),
 	})
 end
--- dump_entities(game.surfaces[1].find_tiles_filtered{position = game.player.position, radius = 32})
-
+-- /c gridworld.map.dump_entities({game.player.selected})
+-- gridworld.map.dump_entities(game.surfaces[1].find_tiles_filtered{position = game.player.position, radius = 32})
 
 return dump_entities

--- a/module/map/dump_entities.lua
+++ b/module/map/dump_entities.lua
@@ -60,8 +60,7 @@ local function dump_entities(entities, removed_entities)
 		end
 		::continue::
 	end
-	game.print(table.concat(map_data, ";"))
-	game.print("Sending "..(#map_data / 3).." pixels to nodejs")
+
 	clusterio_api.send_json("gridworld:tile_data", {
 		type = "pixels",
 		data = table.concat(map_data, ";"),

--- a/module/map/dump_entities.lua
+++ b/module/map/dump_entities.lua
@@ -4,49 +4,64 @@
 
 local clusterio_api = require("modules/clusterio/api")
 
-local function dump_entities(entities)
+local function dump_entities(entities, removed_entities)
+	-- Do removals first, then additions afterwards to avoid issues with entities being removed and added in the same cycle
+	-- Additions check .valid so the race condition can't happen that way
+	local tasks = removed_entities or {}
+	if entities ~= nil then
+		-- Add entities to tasks
+		for _, entity in pairs(entities) do
+			table.insert(tasks, entity)
+		end
+	end
+
 	local map_data = {}
 	-- Get entities in the area
-	for _, entity in pairs(entities) do
+	for _, entity in pairs(tasks) do
 		if entity == nil or entity.valid == false then
 			goto continue
 		end
 		local position = entity.position
-		local map_color = entity.prototype.friendly_map_color or entity.prototype.map_color or entity.prototype.enemy_map_color
-		if map_color ~= nil then
-			local is_resource = entity.prototype.collision_mask["resource-layer"]
-			if is_resource then
-				-- Create checkerboard pattern associated with resources
-				if (math.floor(position.x/2) + math.floor(position.y/2)) % 2 == 0 then
-					table.insert(map_data, position.x)
-					table.insert(map_data, position.y)
-					table.insert(map_data, string.format("%02x%02x%02x", map_color.r, map_color.g, map_color.b))
-				end
-			else
-				-- Determine size of entity to draw
-				-- TODO: Does not seem to get the correct shape for trees and cliffs
-				local size_x = math.ceil((entity.bounding_box.left_top.x - entity.bounding_box.right_bottom.x) * -1)
-				local size_y = math.ceil((entity.bounding_box.left_top.y - entity.bounding_box.right_bottom.y) * -1)
+		local map_color = {r = 255, g = 255, b = 255, a = 0}
+		if entity.valid then
+			map_color = entity.prototype.friendly_map_color or entity.prototype.map_color or entity.prototype.enemy_map_color
+		end
+		if entity.valid == nil and entity.deleted then
+			map_color.a = 0 -- Remove alpha channel to make it transparent
+		end
+		local is_resource = entity.valid and entity.prototype.collision_mask["resource-layer"]
+		if is_resource then
+			-- Create checkerboard pattern associated with resources
+			if (math.floor(position.x/2) + math.floor(position.y/2)) % 2 == 0 then
+				table.insert(map_data, position.x)
+				table.insert(map_data, position.y)
+				table.insert(map_data, string.format("%02x%02x%02x%02x", map_color.r, map_color.g, map_color.b, map_color.a))
+			end
+		else
+			-- Determine size of entity to draw
+			-- TODO: Does not seem to get the correct shape for trees and cliffs, probably due to rotation
+			local size_x = math.ceil((entity.bounding_box.left_top.x - entity.bounding_box.right_bottom.x) * -1)
+			local size_y = math.ceil((entity.bounding_box.left_top.y - entity.bounding_box.right_bottom.y) * -1)
 
-				-- Add pixels
-				for x = 0, size_x-1 do
-					for y = 0, size_y-1 do
-						-- Format as hexadecimal
-						table.insert(map_data, position.x + x - (size_x-1)/2)
-						table.insert(map_data, position.y + y - (size_y-1)/2)
-						if entity.type == "entity-ghost" then
-							-- Render as purple
-							table.insert(map_data, "A800A8")
-						else
-						table.insert(map_data, string.format("%02x%02x%02x", map_color.r, map_color.g, map_color.b))
-						end
+			-- Add pixels
+			for x = 0, size_x-1 do
+				for y = 0, size_y-1 do
+					-- Format as hexadecimal
+					table.insert(map_data, position.x + x - (size_x-1)/2)
+					table.insert(map_data, position.y + y - (size_y-1)/2)
+					if entity.type == "entity-ghost" then
+						-- Render as transparent purple
+						table.insert(map_data, string.format("%02x%02x%02x%02x", 168, 0, 168, 127))
+					else
+						table.insert(map_data, string.format("%02x%02x%02x%02x", map_color.r, map_color.g, map_color.b, map_color.a))
 					end
 				end
 			end
 		end
 		::continue::
 	end
-
+	game.print(table.concat(map_data, ";"))
+	game.print("Sending "..(#map_data / 3).." pixels to nodejs")
 	clusterio_api.send_json("gridworld:tile_data", {
 		type = "pixels",
 		data = table.concat(map_data, ";"),

--- a/module/map/dump_entities.lua
+++ b/module/map/dump_entities.lua
@@ -3,6 +3,7 @@
 ]]
 
 local clusterio_api = require("modules/clusterio/api")
+local ignored_entities = require("modules/gridworld/map/ignored_entities")
 
 local function dump_entities(entities, removed_entities)
 	-- Do removals first, then additions afterwards to avoid issues with entities being removed and added in the same cycle
@@ -18,7 +19,7 @@ local function dump_entities(entities, removed_entities)
 	local map_data = {}
 	-- Get entities in the area
 	for _, entity in pairs(tasks) do
-		if entity == nil or entity.valid == false then
+		if entity == nil or entity.valid == false or ignored_entities[entity.type] then
 			goto continue
 		end
 		local position = entity.position

--- a/module/map/dump_entities.lua
+++ b/module/map/dump_entities.lua
@@ -6,6 +6,9 @@ local clusterio_api = require("modules/clusterio/api")
 local ignored_entities = require("modules/gridworld/map/ignored_entities")
 
 local function dump_entities(entities, removed_entities)
+	-- Only process on the server. Modifying any game state after this statement will desync
+	if not gridworld.is_server_unsafe_desync then return end
+
 	-- Do removals first, then additions afterwards to avoid issues with entities being removed and added in the same cycle
 	-- Additions check .valid so the race condition can't happen that way
 	local tasks = removed_entities or {}

--- a/module/map/dump_mapview.lua
+++ b/module/map/dump_mapview.lua
@@ -27,6 +27,7 @@ local function dump_mapview(position_a, position_b)
 		position = position_a,
 		size = CHUNK_SIZE,
 		data = table.concat(map_data, ";"),
+		layer = "tiles_"
 	})
 end
 -- dump_mapview(game.player.position, {x = game.player.position.x + 128, y = game.player.position.y + 128})

--- a/module/map/dump_mapview.lua
+++ b/module/map/dump_mapview.lua
@@ -5,6 +5,9 @@
 local clusterio_api = require("modules/clusterio/api")
 
 local function dump_mapview(position_a, position_b)
+	-- Only process on the server. Modifying any game state after this statement will desync
+	if not gridworld.is_server_unsafe_desync then return end
+
 	local tiles = game.surfaces[1].find_tiles_filtered{area = {position_a, position_b}}
 
 	local map_data = {}

--- a/module/map/dump_tiles.lua
+++ b/module/map/dump_tiles.lua
@@ -1,0 +1,28 @@
+--[[
+	Dump changed tiles
+
+	Unlike dump_mapview, this one dumps an array of single tiles. This is less
+	space efficient than the chunked format for normal exports, but nmore
+	efficient for many small updates such as what happens when robots build concrete.
+]]
+
+local clusterio_api = require("modules/clusterio/api")
+
+local function dump_tiles(tiles)
+	local map_data = {}
+	for _, tilePosition in pairs(tiles) do
+		local tile = game.surfaces[1].get_tile(tilePosition)
+		local map_color = tile.prototype.map_color
+		table.insert(map_data, tilePosition.x)
+		table.insert(map_data, tilePosition.y)
+		table.insert(map_data, string.format("%02x%02x%02x%02x", map_color.r, map_color.g, map_color.b, map_color.a))
+	end
+
+	clusterio_api.send_json("gridworld:tile_data", {
+		type = "pixels",
+		data = table.concat(map_data, ";"),
+		layer = "tiles_",
+	})
+end
+
+return dump_tiles

--- a/module/map/dump_tiles.lua
+++ b/module/map/dump_tiles.lua
@@ -9,6 +9,9 @@
 local clusterio_api = require("modules/clusterio/api")
 
 local function dump_tiles(tiles)
+	-- Only process on the server. Modifying any game state after this statement will desync
+	if not gridworld.is_server_unsafe_desync then return end
+
 	local map_data = {}
 	for _, tilePosition in pairs(tiles) do
 		local tile = game.surfaces[1].get_tile(tilePosition)

--- a/module/map/entity_added.lua
+++ b/module/map/entity_added.lua
@@ -1,8 +1,19 @@
+local ignored_entities = require("modules/gridworld/map/ignored_entities")
+
 local function on_entity_added(_, entity)
+	if ignored_entities[entity.type] then
+		return
+	end
 	if global.gridworld.map.added_entities_to_update == nil then
 		global.gridworld.map.added_entities_to_update = {}
 	end
 	table.insert(global.gridworld.map.added_entities_to_update, entity)
+	local registration = script.register_on_entity_destroyed(entity)
+	global.gridworld.map.entity_registrations[registration] = {
+		position = entity.position,
+		bounding_box = entity.bounding_box,
+		deleted = true,
+	}
 end
 
 return on_entity_added

--- a/module/map/entity_removed.lua
+++ b/module/map/entity_removed.lua
@@ -1,6 +1,10 @@
--- TODO: Add batching of updates with on_nth_tick
-local function on_entity_removed(_event)
-	-- dump_entities({event.entity})
+local function on_entity_removed(event)
+	if global.gridworld.map.removed_entities_to_update == nil then
+		global.gridworld.map.removed_entities_to_update = {}
+	end
+	local entity = global.gridworld.map.entity_registrations[event.registration_number]
+	table.insert(global.gridworld.map.removed_entities_to_update, entity)
+	global.gridworld.map.entity_registrations[event.registration_number] = nil
 end
 
 return on_entity_removed

--- a/module/map/entity_removed_unregistered.lua
+++ b/module/map/entity_removed_unregistered.lua
@@ -1,0 +1,18 @@
+local ignored_entities = require("modules/gridworld/map/ignored_entities")
+
+local function on_entity_removed(event)
+	local entity = event.entity or event.cliff
+	if ignored_entities[entity.type] then
+		return
+	end
+	if global.gridworld.map.removed_entities_to_update == nil then
+		global.gridworld.map.removed_entities_to_update = {}
+	end
+	table.insert(global.gridworld.map.removed_entities_to_update, {
+		position = entity.position,
+		bounding_box = entity.bounding_box,
+		deleted = true,
+	})
+end
+
+return on_entity_removed

--- a/module/map/events/on_chunk_generated.lua
+++ b/module/map/events/on_chunk_generated.lua
@@ -1,0 +1,15 @@
+local entity_added = require("modules/gridworld/map/entity_added")
+local dump_mapview = require("modules/gridworld/map/dump_mapview")
+
+local function on_chunk_generated(event)
+	-- Process entities
+	local entities = event.surface.find_entities_filtered({area = event.area})
+	for _, entity in pairs(entities) do
+		entity_added(nil, entity)
+	end
+
+	-- Process tiles
+	dump_mapview({event.area.left_top.x, event.area.left_top.y}, {event.area.right_bottom.x, event.area.right_bottom.y})
+end
+
+return on_chunk_generated

--- a/module/map/events/on_nth_tick.lua
+++ b/module/map/events/on_nth_tick.lua
@@ -1,7 +1,7 @@
 local dump_entities = require("modules/gridworld/map/dump_entities")
 
 local function on_nth_tick()
-	if global.gridworld.map.added_entities_to_update or #global.gridworld.map.removed_entities_to_update > 0 then
+	if global.gridworld.map.added_entities_to_update or (global.gridworld.map.removed_entities_to_update and #global.gridworld.map.removed_entities_to_update > 0) then
 		dump_entities(global.gridworld.map.added_entities_to_update, global.gridworld.map.removed_entities_to_update)
 		global.gridworld.map.added_entities_to_update = nil
 		global.gridworld.map.removed_entities_to_update = {}

--- a/module/map/events/on_nth_tick.lua
+++ b/module/map/events/on_nth_tick.lua
@@ -1,10 +1,15 @@
 local dump_entities = require("modules/gridworld/map/dump_entities")
+local dump_tiles = require("modules/gridworld/map/dump_tiles")
 
 local function on_nth_tick()
 	if global.gridworld.map.added_entities_to_update or (global.gridworld.map.removed_entities_to_update and #global.gridworld.map.removed_entities_to_update > 0) then
 		dump_entities(global.gridworld.map.added_entities_to_update, global.gridworld.map.removed_entities_to_update)
 		global.gridworld.map.added_entities_to_update = nil
 		global.gridworld.map.removed_entities_to_update = {}
+	end
+	if global.gridworld.map.tiles_to_update ~= nil then
+		dump_tiles(global.gridworld.map.tiles_to_update)
+		global.gridworld.map.tiles_to_update = nil
 	end
 end
 

--- a/module/map/events/on_nth_tick.lua
+++ b/module/map/events/on_nth_tick.lua
@@ -1,9 +1,10 @@
 local dump_entities = require("modules/gridworld/map/dump_entities")
 
 local function on_nth_tick()
-	if global.gridworld.map.added_entities_to_update then
-		dump_entities(global.gridworld.map.added_entities_to_update)
+	if global.gridworld.map.added_entities_to_update or #global.gridworld.map.removed_entities_to_update > 0 then
+		dump_entities(global.gridworld.map.added_entities_to_update, global.gridworld.map.removed_entities_to_update)
 		global.gridworld.map.added_entities_to_update = nil
+		global.gridworld.map.removed_entities_to_update = {}
 	end
 end
 

--- a/module/map/events/on_tile_changed.lua
+++ b/module/map/events/on_tile_changed.lua
@@ -1,0 +1,11 @@
+local function on_tile_changed(event)
+	local tiles = event.tiles
+	if global.gridworld.map.tiles_to_update == nil then
+		global.gridworld.map.tiles_to_update = {}
+	end
+	for _, tile in pairs(tiles) do
+		table.insert(global.gridworld.map.tiles_to_update, tile.position)
+	end
+end
+
+return on_tile_changed

--- a/module/map/ignored_entities.lua
+++ b/module/map/ignored_entities.lua
@@ -1,0 +1,13 @@
+local ignored_entities = {
+	-- "entity-ghost", -- Should be rendered as transparent purple
+	"locomotive",
+	"cargo-wagon",
+	"fluid-wagon",
+	"artillery-wagon",
+	"car",
+	"spider-vehicle",
+	"character",
+	"character-corpse",
+}
+
+return ignored_entities

--- a/module/map/ignored_entities.lua
+++ b/module/map/ignored_entities.lua
@@ -8,6 +8,7 @@ local ignored_entities = {
 	"spider-vehicle",
 	"character",
 	"character-corpse",
+	"fish",
 }
 
 return ignored_entities

--- a/module/map/ignored_entities.lua
+++ b/module/map/ignored_entities.lua
@@ -1,14 +1,14 @@
 local ignored_entities = {
 	-- "entity-ghost", -- Should be rendered as transparent purple
-	"locomotive",
-	"cargo-wagon",
-	"fluid-wagon",
-	"artillery-wagon",
-	"car",
-	"spider-vehicle",
-	"character",
-	"character-corpse",
-	"fish",
+	["locomotive"] = true,
+	["cargo-wagon"] = true,
+	["fluid-wagon"] = true,
+	["artillery-wagon"] = true,
+	["car"] = true,
+	["spider-vehicle"] = true,
+	["character"] = true,
+	["character-corpse"] = true,
+	["fish"] = true,
 }
 
 return ignored_entities

--- a/module/map/map.lua
+++ b/module/map/map.lua
@@ -7,6 +7,7 @@ local entity_removed_unregistered = require("modules/gridworld/map/entity_remove
 
 local on_nth_tick = require("modules/gridworld/map/events/on_nth_tick")
 local on_chunk_generated = require("modules/gridworld/map/events/on_chunk_generated")
+local on_tile_changed = require("modules/gridworld/map/events/on_tile_changed")
 
 return {
 	dump_mapview = dump_mapview,
@@ -26,5 +27,11 @@ return {
 		on_robot_mined_entity = entity_removed_unregistered,
 		on_entity_died = entity_removed_unregistered,
 		on_pre_robot_exploded_cliff = entity_removed_unregistered,
+		-- Tile update events
+		on_player_built_tile = on_tile_changed,
+		on_player_mined_tile = on_tile_changed,
+		on_robot_built_tile = on_tile_changed,
+		on_robot_mined_tile = on_tile_changed,
+		script_raised_set_tiles = on_tile_changed,
 	},
 }

--- a/module/map/map.lua
+++ b/module/map/map.lua
@@ -3,6 +3,7 @@ local dump_entities = require("modules/gridworld/map/dump_entities")
 
 local entity_added = require("modules/gridworld/map/entity_added")
 local entity_removed = require("modules/gridworld/map/entity_removed")
+local entity_removed_unregistered = require("modules/gridworld/map/entity_removed_unregistered")
 
 local on_nth_tick = require("modules/gridworld/map/events/on_nth_tick")
 
@@ -12,10 +13,16 @@ return {
 	events = {
 		on_nth_tick = on_nth_tick,
 		on_built_entity = entity_added,
+		on_biter_base_built = entity_added,
 		on_entity_cloned = entity_added,
 		on_entity_destroyed = entity_removed,
 		on_robot_built_entity = entity_added,
 		script_raised_built = entity_added,
 		script_raised_revive = entity_added,
+		-- Pre-destruction events, not reliable but used for cleanup of things we havent registered
+		on_player_mined_entity = entity_removed_unregistered,
+		on_robot_mined_entity = entity_removed_unregistered,
+		on_entity_died = entity_removed_unregistered,
+		on_pre_robot_exploded_cliff = entity_removed_unregistered,
 	},
 }

--- a/module/map/map.lua
+++ b/module/map/map.lua
@@ -6,6 +6,7 @@ local entity_removed = require("modules/gridworld/map/entity_removed")
 local entity_removed_unregistered = require("modules/gridworld/map/entity_removed_unregistered")
 
 local on_nth_tick = require("modules/gridworld/map/events/on_nth_tick")
+local on_chunk_generated = require("modules/gridworld/map/events/on_chunk_generated")
 
 return {
 	dump_mapview = dump_mapview,
@@ -19,6 +20,7 @@ return {
 		on_robot_built_entity = entity_added,
 		script_raised_built = entity_added,
 		script_raised_revive = entity_added,
+		on_chunk_generated = on_chunk_generated,
 		-- Pre-destruction events, not reliable but used for cleanup of things we havent registered
 		on_player_mined_entity = entity_removed_unregistered,
 		on_robot_mined_entity = entity_removed_unregistered,

--- a/src/mapview/tileDataEventHandler.js
+++ b/src/mapview/tileDataEventHandler.js
@@ -4,13 +4,13 @@ const path = require("path");
 sharp.cache(false);
 const sleep = require("../util/sleep");
 
+const TILE_SIZE = 512;
 const fileLocks = {}; // Used to prevent multiple writes to the same file
 const updates = new Map();
 
-module.exports = async function tileDataEventHandler({ type, data, size, position }) {
+module.exports = async function tileDataEventHandler({ type, data, size, position, layer }) {
 	// console.log(type, size, position);
 	// Image tiles are 512x512 pixels arranged in a grid, starting at 0,0
-	const TILE_SIZE = 512;
 	if (type === "pixels") {
 		if (data.length % 3 !== 0) {
 			this.logger.error(`Invalid pixel data length: ${data.length}`);
@@ -24,7 +24,7 @@ module.exports = async function tileDataEventHandler({ type, data, size, positio
 			// Figure out which image tile the pixel belongs to
 			const x_tile = (x - x % TILE_SIZE) / TILE_SIZE + (x < 0 ? -1 : 0);
 			const y_tile = (y - y % TILE_SIZE) / TILE_SIZE + (y < 0 ? -1 : 0);
-			const filename = `z10x${x_tile}y${y_tile}.png`;
+			const filename = `${layer}z10x${x_tile}y${y_tile}.png`;
 			if (!updates.has(filename)) {
 				updates.set(filename, new Set());
 			}
@@ -51,7 +51,7 @@ module.exports = async function tileDataEventHandler({ type, data, size, positio
 			const pixel_world_y = originPosition[1] + y;
 			const x_tile = (pixel_world_x - pixel_world_x % TILE_SIZE) / TILE_SIZE + (pixel_world_x < 0 ? -1 : 0);
 			const y_tile = (pixel_world_y - pixel_world_y % TILE_SIZE) / TILE_SIZE + (pixel_world_y < 0 ? -1 : 0);
-			const filename = `tiles_z10x${x_tile}y${y_tile}.png`;
+			const filename = `${layer}z10x${x_tile}y${y_tile}.png`;
 			if (!updates.has(filename)) {
 				updates.set(filename, new Set());
 			}

--- a/src/mapview/tileDataEventHandler.js
+++ b/src/mapview/tileDataEventHandler.js
@@ -10,11 +10,10 @@ module.exports = async function tileDataEventHandler({ type, data, size, positio
 	// Image tiles are 512x512 pixels arranged in a grid, starting at 0,0
 	const TILE_SIZE = 512;
 	if (type === "pixels") {
-		// console.log(data);
 		for (let i = 0; i < data.length; i += 3) {
 			const x = Math.floor(data[i]); // Convert from string and strip decimals
 			const y = Math.floor(data[i + 1]); // Convert from string and strip decimals
-			const rgba = [Number(`0x${data[i + 2].slice(0, 2)}`), Number(`0x${data[i + 2].slice(2, 4)}`), Number(`0x${data[i + 2].slice(4, 6)}`), 255];
+			const rgba = [Number(`0x${data[i + 2].slice(0, 2)}`), Number(`0x${data[i + 2].slice(2, 4)}`), Number(`0x${data[i + 2].slice(4, 6)}`), Number(`0x${data[i + 2].slice(6, 8)}`)];
 
 			// Figure out which image tile the pixel belongs to
 			const x_tile = (x - x % TILE_SIZE) / TILE_SIZE + (x < 0 ? -1 : 0);

--- a/src/mapview/tileDataEventHandler.js
+++ b/src/mapview/tileDataEventHandler.js
@@ -2,14 +2,20 @@
 const sharp = require("sharp");
 const path = require("path");
 sharp.cache(false);
-const messages = require("../../messages");
+const sleep = require("../util/sleep");
+
+const fileLocks = {}; // Used to prevent multiple writes to the same file
+const updates = new Map();
 
 module.exports = async function tileDataEventHandler({ type, data, size, position }) {
 	// console.log(type, size, position);
-	const updates = new Map();
 	// Image tiles are 512x512 pixels arranged in a grid, starting at 0,0
 	const TILE_SIZE = 512;
 	if (type === "pixels") {
+		if (data.length % 3 !== 0) {
+			this.logger.error(`Invalid pixel data length: ${data.length}`);
+			return;
+		}
 		for (let i = 0; i < data.length; i += 3) {
 			const x = Math.floor(data[i]); // Convert from string and strip decimals
 			const y = Math.floor(data[i + 1]); // Convert from string and strip decimals
@@ -56,44 +62,71 @@ module.exports = async function tileDataEventHandler({ type, data, size, positio
 			]);
 		}
 	}
+
 	// Perform image updates
 	for (const [filename, pixels] of updates) {
-		// console.log("updating", filename);
-		// Check if image exists, otherwise create one
-		let raw;
-		try {
-			raw = await sharp(path.resolve(this._tilesPath, filename))
-				.raw()
-				.toBuffer();
-		} catch (e) {
-			raw = await sharp({
-				create: {
+		// Wait for previous calls to complete before we take over the file locks
+		const imagePath = path.resolve(this._tilesPath, filename);
+		if (!fileLocks[imagePath]) {
+			fileLocks[imagePath] = [];
+		}
+		// Already waiting, cancel
+		if (fileLocks[imagePath].length > 1) {
+			return;
+		}
+		if (fileLocks[imagePath].length > 0) {
+			// const timer = `Waiting for tile lock ${filename}`;
+			// console.time(timer);
+			fileLocks[imagePath].push(true); // Since we are waiting, we don't need to let later calls also wait
+			await Promise.all(fileLocks[imagePath]);
+			// console.timeEnd(timer);
+		}
+		fileLocks[imagePath] = []; // No need to leak memory
+		fileLocks[imagePath].push(new Promise(async (resolve) => {
+			// Check if image exists, otherwise create one
+			let raw;
+			try {
+				raw = await sharp(imagePath)
+					.raw()
+					.toBuffer();
+			} catch (e) {
+				raw = await sharp({
+					create: {
+						width: TILE_SIZE,
+						height: TILE_SIZE,
+						channels: 4,
+						background: { r: 20, g: 20, b: 20, alpha: 0 },
+					},
+				})
+					.raw()
+					.toBuffer();
+			}
+			// Write pixels
+			for (const [x, y, rgba] of pixels) {
+				const index = (y * TILE_SIZE + x) * 4;
+				raw[index] = rgba[0];
+				raw[index + 1] = rgba[1];
+				raw[index + 2] = rgba[2];
+				raw[index + 3] = rgba[3];
+			}
+			// Clear processed pixels. MUST be done before further async operations
+			pixels.clear();
+			// Convert back to sharp and write to file
+			await sharp(raw, {
+				raw: {
 					width: TILE_SIZE,
 					height: TILE_SIZE,
 					channels: 4,
-					background: { r: 20, g: 20, b: 20, alpha: 0 },
 				},
 			})
-				.raw()
-				.toBuffer();
-		}
-		// Write pixels
-		for (const [x, y, rgba] of pixels) {
-			const index = (y * TILE_SIZE + x) * 4;
-			raw[index] = rgba[0];
-			raw[index + 1] = rgba[1];
-			raw[index + 2] = rgba[2];
-			raw[index + 3] = rgba[3];
-		}
-		// Convert back to sharp and write to file
-		await sharp(raw, {
-			raw: {
-				width: TILE_SIZE,
-				height: TILE_SIZE,
-				channels: 4,
-			},
-		})
-			.png()
-			.toFile(path.resolve(this._tilesPath, filename));
+				.png()
+				.toFile(imagePath);
+			await sleep(250); // Reduce IOPS a bit by batching updates
+			resolve();
+			if (fileLocks[imagePath].length > 0) {
+				// Nothing is waiting, clear the lock queue
+				fileLocks[imagePath] = [];
+			}
+		}));
 	}
 };

--- a/src/mapview/tileDataIpcHandler.js
+++ b/src/mapview/tileDataIpcHandler.js
@@ -2,7 +2,7 @@
 
 const messages = require("./../../messages");
 
-module.exports = async function handleTileDataIpc(instancePlugin, json) {
+module.exports = async function tileDataIpcHandler(instancePlugin, json) {
 	let tileData = json.data.split(";");
 	if (!Array.isArray(tileData)) {
 		instancePlugin.logger.error(`Received tile data with invalid data (should be array) ${json.data}`);
@@ -13,5 +13,13 @@ module.exports = async function handleTileDataIpc(instancePlugin, json) {
 		instancePlugin.logger.error(`Received tile data with invalid type ${type}`);
 	}
 
-	await instancePlugin.instance.sendTo("controller", new messages.TileData(type, tileData, json.position, json.size, json.layer));
+	await instancePlugin.instance.sendTo("controller", new messages.TileData(
+		type,
+		tileData,
+		json.position,
+		json.size,
+		instancePlugin.instance.config.get("instance.id"),
+		instancePlugin.instance.config.get("gridworld.grid_id"),
+		json.layer
+	));
 };

--- a/src/mapview/tileDataIpcHandler.js
+++ b/src/mapview/tileDataIpcHandler.js
@@ -13,5 +13,5 @@ module.exports = async function handleTileDataIpc(instancePlugin, json) {
 		instancePlugin.logger.error(`Received tile data with invalid type ${type}`);
 	}
 
-	await instancePlugin.instance.sendTo("controller", new messages.TileData(type, tileData, json.position, json.size));
+	await instancePlugin.instance.sendTo("controller", new messages.TileData(type, tileData, json.position, json.size, json.layer));
 };

--- a/web/components/GridVisualizer.jsx
+++ b/web/components/GridVisualizer.jsx
@@ -31,7 +31,7 @@ export default function GridVisualizer(props) {
 			setRefreshTiles(Math.floor(Math.random() * 10000).toString());
 		}, 2500);
 		return () => clearInterval(interval);
-	});
+	}, []);
 
 	return <>
 		<div className="grid-visualizer">

--- a/web/components/GridVisualizer.jsx
+++ b/web/components/GridVisualizer.jsx
@@ -56,17 +56,18 @@ export default function GridVisualizer(props) {
 							])
 						).flat() ?? [])}
 						maxZoom={18}
+						minZoom={7}
 						crs={L.CRS.Simple}
 					>
 						<TileLayerCustom
 							url={`${document.location.origin}/api/gridworld/tiles/{z}/{x}/{y}.png?refresh=${refreshTiles}`}
 							maxNativeZoom={10} // 10 max
-							minNativeZoom={7} // 7 min
+							minNativeZoom={10} // 7 min
 						/>
 						<TileLayerCustom
 							url={`${document.location.origin}/api/gridworld/entities/{z}/{x}/{y}.png?refresh=${refreshTiles}`}
 							maxNativeZoom={10} // 10 max
-							minNativeZoom={7} // 7 min
+							minNativeZoom={10} // 7 min
 						/>
 						{mapData?.map_data?.map?.(instance => <div key={instance.instance_id}>
 							{instance.edges.map(edge => {


### PR DESCRIPTION
- Draw entities with correct size
- Correct opacity
- Sync removal of entities
- Draw ghosts as purple

Issues to solve:
- [x] Not all existing entities (unregistered) are removed when destroyed
- [ ] Cliffs don't show quite right due to rotation not being considered
- [x] Out of area tiles/entities that overlap with other instances should not be rendered
- [x] Update map when tiles are placed/mined