### PR TITLE
Map merging

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -149,6 +149,8 @@ do -- Factorio STDs--
 			'serpent',
 			-- @table_size@: Returns the number of elements inside an LUA table.
 			'table_size',
+			-- @loadstring@: Loads a string as a Lua chunk.
+			'loadstring',
 			-- @lldebugger@: Provided by lua local debugger vscode extension.
 			lldebugger = {fields = {'requestBreak'}, other_fields = true, read_only = false},
 			-- @__DebugAdapter@: Provided by Factorio Mod Debug vscode extension.

--- a/controller.js
+++ b/controller.js
@@ -32,6 +32,7 @@ const claimServerRequestHandler = require("./src/request_handlers/claimServerReq
 const unclaimServerRequestHandler = require("./src/request_handlers/unclaimServerRequestHandler");
 const setLoadFactorEventHandler = require("./src/event_handlers/setLoadFactorEventHandler");
 const tileDataEventHandler = require("./src/mapview/tileDataEventHandler");
+const startMapMergeRequestHandler = require("./src/request_handlers/startMapMergeRequestHandler");
 
 async function loadDatabase(config, filename, logger) {
 	let itemsPath = path.resolve(config.get("controller.database_directory"), filename);
@@ -105,6 +106,7 @@ class ControllerPlugin extends BaseControllerPlugin {
 		this.controller.handle(messages.UnclaimServer, unclaimServerRequestHandler.bind(this));
 		this.controller.handle(messages.SetLoadFactor, setLoadFactorEventHandler.bind(this));
 		this.controller.handle(messages.TileData, tileDataEventHandler.bind(this));
+		this.controller.handle(messages.StartMapMerge, startMapMergeRequestHandler.bind(this));
 	}
 
 	async onInstanceStatusChanged(instance) {

--- a/controller.js
+++ b/controller.js
@@ -65,6 +65,21 @@ class ControllerPlugin extends BaseControllerPlugin {
 	async init() {
 		this.gridworldDatastore = await loadDatabase(this.controller.config, "gridworld.json", this.logger);
 		this.factionsDatastore = await loadDatabase(this.controller.config, "factions.json", this.logger);
+		this.gridworlds = new Map();
+		// Reconstruct gridworld information by iterating over all instances and finding lobby servers
+		for (let [instanceId, instance] of this.controller.instances) {
+			if (instance.config.get("gridworld.is_lobby_server")) {
+				this.gridworlds.set(instance.config.get("gridworld.grid_id"), {
+					lobby_server: instanceId,
+					id: instance.config.get("gridworld.grid_id"),
+					name_prefix: instance.config.get("gridworld.grid_name_prefix"),
+					x_size: instance.config.get("gridworld.grid_x_size"),
+					y_size: instance.config.get("gridworld.grid_y_size"),
+					use_edge_transports: true, // TODO: This should not be hardcoded
+				});
+			}
+		}
+
 		this.autosaveId = setInterval(() => {
 			saveDatabase(this.controller.config, this.gridworldDatastore, "gridworld.json", this.logger).catch(err => {
 				this.logger.error(`Unexpected error autosaving gridworld data:\n${err.stack}`);

--- a/index.js
+++ b/index.js
@@ -151,6 +151,7 @@ module.exports = {
 			"/gridworld/create",
 			"/gridworld/factions",
 			"/gridworld/factions/:factionId/view",
+			"/gridworld/merge_map",
 		],
 
 		messages: [

--- a/index.js
+++ b/index.js
@@ -48,6 +48,12 @@ lib.definePermission({
 	description: "Delete *any* faction",
 	grantByDefault: false,
 });
+lib.definePermission({
+	name: "gridworld.merge.start",
+	title: "Start merge",
+	description: "Merge instances to a single map. Resource intensive",
+	grantByDefault: false,
+});
 
 module.exports = {
 	plugin: {

--- a/index.js
+++ b/index.js
@@ -93,6 +93,12 @@ module.exports = {
 				description: "Make this instance act as a lobby server for a gridworld",
 				initialValue: false,
 			},
+			"gridworld.is_grid_square": {
+				type: "boolean",
+				title: "Server is a grid square",
+				description: "Make this instance act as a grid square for a gridworld",
+				initialValue: false,
+			},
 			"gridworld.grid_id": {
 				type: "number",
 				title: "Grid ID",

--- a/instance.js
+++ b/instance.js
@@ -105,6 +105,7 @@ class InstancePlugin extends BaseInstancePlugin {
 			world_y: this.instance.config.get("gridworld.grid_y_position"),
 		};
 		await this.sendRcon("/sc gridworld.is_server_unsafe_desync = true");
+		await this.sendRcon("/sc global.disable_crashsite = true");
 		if (this.instance.config.get("gridworld.is_lobby_server")) {
 			await this.sendRcon("/sc gridworld.register_lobby_server(true)");
 			// Get gridworld data
@@ -113,7 +114,6 @@ class InstancePlugin extends BaseInstancePlugin {
 		}
 		if (this.instance.config.get("gridworld.is_grid_square")) {
 			await this.sendRcon("/sc global.is_grid_square = true");
-			await this.sendRcon("/sc global.disable_crashsite = true");
 			await this.sendRcon(`/sc gridworld.create_world_limit("${data.x_size}","${data.y_size}","${data.world_x}","${data.world_y}", false)`, true);
 			await this.sendRcon(`/sc gridworld.create_spawn("${data.x_size}","${data.y_size}","${data.world_x}","${data.world_y}", false)`, true);
 			// Update neighboring nodes for edge_transports

--- a/instance.js
+++ b/instance.js
@@ -110,7 +110,9 @@ class InstancePlugin extends BaseInstancePlugin {
 			// Get gridworld data
 			const { map_data } = await this.instance.sendTo("controller", new messages.GetMapData());
 			await this.sendRcon(`/sc gridworld.register_map_data('${JSON.stringify(map_data)}')`);
-		} else {
+		}
+		if (this.instance.config.get("gridworld.is_grid_square")) {
+			await this.sendRcon("/sc global.is_grid_square = true");
 			await this.sendRcon("/sc global.disable_crashsite = true");
 			await this.sendRcon(`/sc gridworld.create_world_limit("${data.x_size}","${data.y_size}","${data.world_x}","${data.world_y}", false)`, true);
 			await this.sendRcon(`/sc gridworld.create_spawn("${data.x_size}","${data.y_size}","${data.world_x}","${data.world_y}", false)`, true);

--- a/messages.js
+++ b/messages.js
@@ -30,6 +30,13 @@ module.exports = {
 		toJSON() {
 			return this.data;
 		}
+		static Response = plainJson({
+			type: "object",
+			properties: {
+				ok: { type: "boolean" },
+				message: { type: "string" },
+			},
+		});
 	},
 	GetMapData: class GetMapData {
 		static type = "request";
@@ -182,6 +189,7 @@ module.exports = {
 			properties: {
 				player_position: { type: "boolean" },
 				faction_list: { type: "boolean" },
+				gridworlds: { type: "boolean" },
 			},
 		};
 		constructor(data) {
@@ -680,12 +688,41 @@ module.exports = {
 				grid_id: { type: "integer" },
 			},
 		};
-		constructor(host_id, grid_id) {
-			this.host_id = host_id;
-			this.grid_id = grid_id;
+		constructor(data) {
+			this.host_id = data.host_id;
+			this.grid_id = data.grid_id;
 		}
 		static fromJSON(json) {
-			return new this(json.host_id, json.grid_id);
+			return new this(json);
+		}
+	},
+	GridworldUpdate: class GridworldUpdate {
+		static type = "event";
+		static src = "controller";
+		static dst = "control";
+		static plugin = pluginName;
+		static permission = "gridworld.overview.view";
+		static jsonSchema = {
+			type: "object",
+			properties: {
+				lobby_server: { type: "integer" }, // Lobby server instance ID
+				id: { type: "integer" }, // grid_id
+				name_prefix: { type: "string" },
+				x_size: { type: "integer" },
+				y_size: { type: "integer" },
+				use_edge_transports: { type: "boolean" },
+			},
+		};
+		constructor(data) {
+			this.lobby_server = data.lobby_server;
+			this.id = data.id;
+			this.name_prefix = data.name_prefix;
+			this.x_size = data.x_size;
+			this.y_size = data.y_size;
+			this.use_edge_transports = data.use_edge_transports;
+		}
+		static fromJSON(json) {
+			return new this(json);
 		}
 	},
 };

--- a/messages.js
+++ b/messages.js
@@ -688,6 +688,14 @@ module.exports = {
 				grid_id: { type: "integer" },
 			},
 		};
+		static Response = plainJson({
+			type: "object",
+			properties: {
+				ok: { type: "boolean" },
+				message: { type: "string" },
+				instance_id: { type: "integer" },
+			},
+		});
 		constructor(data) {
 			this.host_id = data.host_id;
 			this.grid_id = data.grid_id;

--- a/messages.js
+++ b/messages.js
@@ -664,4 +664,28 @@ module.exports = {
 			return this.data;
 		}
 	},
+	StartMapMerge: class StartMapMerge {
+		static type = "request";
+		static src = "control";
+		static dst = "controller";
+		static plugin = pluginName;
+		static permission = "gridworld.merge.start";
+		static jsonSchema = {
+			type: "object",
+			required: ["host_id", "grid_id"],
+			properties: {
+				// Target host
+				host_id: { type: "integer" },
+				// Grid to merge
+				grid_id: { type: "integer" },
+			},
+		};
+		constructor(host_id, grid_id) {
+			this.host_id = host_id;
+			this.grid_id = grid_id;
+		}
+		static fromJSON(json) {
+			return new this(json.host_id, json.grid_id);
+		}
+	},
 };

--- a/module/.gitignore
+++ b/module/.gitignore
@@ -1,0 +1,4 @@
+/luarocks
+/lua
+/lua_modules
+/.luarocks

--- a/module/edge_teleport.lua
+++ b/module/edge_teleport.lua
@@ -37,7 +37,7 @@ local function check_player_position()
 	local y_min = y_size * world_y
 
 	for _,player in pairs(game.connected_players) do
-		if out_of_bounds(player.position.x, player.position.y) then
+		if global.is_grid_square and out_of_bounds(player.position.x, player.position.y) then
 			if not global.gridworld.players[player.name].has_been_offered_teleport and player.character ~= nil then
 				-- north=6, east=0, south=2, and west=4
 				-- Check north edge

--- a/module/gridworld.lua
+++ b/module/gridworld.lua
@@ -29,6 +29,7 @@ local set_player_permission_group = require("faction/building_restrictions/set_p
 local worldgen = require("worldgen/index")
 local load_balancing = require("load_balancing/load_balancing")
 local merge_map = require("merge_map/merge_map")
+local universal_serializer = require("universal_serializer/universal_serializer")
 
 gridworld.events = {}
 gridworld.events[clusterio_api.events.on_server_startup] = function()
@@ -248,6 +249,7 @@ gridworld.events[defines.events.on_tick] = function(event)
 	if not global.gridworld.lobby_server then
 		worldgen.events.on_tick(event)
 	end
+	universal_serializer.events.on_tick(event)
 end
 gridworld.events[defines.events.on_player_built_tile] = function(event)
 	if not global.gridworld.lobby_server then

--- a/module/gridworld.lua
+++ b/module/gridworld.lua
@@ -118,7 +118,7 @@ gridworld.events[defines.events.on_built_entity] = function(event)
 		local x = entity.position.x
 		local y = entity.position.y
 
-		if out_of_bounds(x,y) then
+		if global.is_grid_square and out_of_bounds(x,y) then
 			if player and player.valid then
 				-- Tell the player what is happening
 				-- if player then player.print("Attempted building outside allowed area (placed at x "..x.." y "..y..")") end

--- a/module/gridworld.lua
+++ b/module/gridworld.lua
@@ -28,6 +28,7 @@ local gui_events = require("gui/events")
 local set_player_permission_group = require("faction/building_restrictions/set_player_permission_group")
 local worldgen = require("worldgen/index")
 local load_balancing = require("load_balancing/load_balancing")
+local merge_map = require("merge_map/merge_map")
 
 gridworld.events = {}
 gridworld.events[clusterio_api.events.on_server_startup] = function()
@@ -331,5 +332,6 @@ gridworld.map = {
 	dump_entities = map.dump_entities,
 	dump_mapview = map.dump_mapview,
 }
+gridworld.merge_map = merge_map
 
 return gridworld

--- a/module/map/dump_tiles.lua
+++ b/module/map/dump_tiles.lua
@@ -14,6 +14,7 @@ local function dump_tiles(tiles)
 
 	local map_data = {}
 	for _, tilePosition in pairs(tiles) do
+		---@diagnostic disable-next-line: missing-parameter
 		local tile = game.surfaces[1].get_tile(tilePosition)
 		local map_color = tile.prototype.map_color
 		table.insert(map_data, tilePosition.x)

--- a/module/merge_map/deserialize_entities.lua
+++ b/module/merge_map/deserialize_entities.lua
@@ -11,7 +11,7 @@ local function deserialize_entities(string)
 
 	local entities = {}
 	for _, serialized_entity in pairs(serialized_entities) do
-		local entity = universal_serializer.entity.deserialize(serialized_entity)
+		local entity = universal_serializer.LuaEntity.deserialize(serialized_entity)
 		table.insert(entities, entity)
 	end
 

--- a/module/merge_map/deserialize_entities.lua
+++ b/module/merge_map/deserialize_entities.lua
@@ -1,0 +1,22 @@
+local universal_serializer = require("modules/gridworld/universal_serializer/universal_serializer")
+
+--[[
+	Deserialize entities on merge target world
+]]
+local function deserialize_entities(string)
+	local serialized_entities = game.json_to_table(string)
+	if type(serialized_entities) ~= "table" then
+		error("Expected a table, got " .. type(serialized_entities))
+	end
+
+	local entities = {}
+	for _, serialized_entity in pairs(serialized_entities) do
+		local entity = universal_serializer.entity.deserialize(serialized_entity)
+		table.insert(entities, entity)
+	end
+
+	rcon.print("Deserialized " .. #entities .. " entities")
+	return entities
+end
+
+return deserialize_entities

--- a/module/merge_map/get_tile_colors.lua
+++ b/module/merge_map/get_tile_colors.lua
@@ -1,0 +1,20 @@
+--[[
+	Function that returns a map of tile name to map color
+]]
+local function get_tile_colors(use_rcon)
+	if use_rcon == nil then use_rcon = true end
+
+	local tile_colors = {}
+	for k, v in pairs(game.tile_prototypes) do
+		if v.map_color then
+			tile_colors[v.name] = v.map_color
+		end
+	end
+
+	--[[ Convert to json ]]
+	local tile_colors_json = game.table_to_json(tile_colors)
+	if use_rcon then rcon.print(tile_colors_json) end
+	return tile_colors
+end
+
+return get_tile_colors

--- a/module/merge_map/merge_map.lua
+++ b/module/merge_map/merge_map.lua
@@ -1,0 +1,5 @@
+local prepare_chunks = require("modules/gridworld/merge_map/prepare_chunks")
+
+return {
+	prepare_chunks = prepare_chunks,
+}

--- a/module/merge_map/merge_map.lua
+++ b/module/merge_map/merge_map.lua
@@ -1,5 +1,5 @@
-local prepare_chunks = require("modules/gridworld/merge_map/prepare_chunks")
-
 return {
-	prepare_chunks = prepare_chunks,
+	prepare_chunks = require("modules/gridworld/merge_map/prepare_chunks"),
+	get_tile_colors = require("modules/gridworld/merge_map/get_tile_colors"),
+	set_map_tile_data = require("modules/gridworld/merge_map/set_map_tile_data"),
 }

--- a/module/merge_map/merge_map.lua
+++ b/module/merge_map/merge_map.lua
@@ -2,4 +2,6 @@ return {
 	prepare_chunks = require("modules/gridworld/merge_map/prepare_chunks"),
 	get_tile_colors = require("modules/gridworld/merge_map/get_tile_colors"),
 	set_map_tile_data = require("modules/gridworld/merge_map/set_map_tile_data"),
+	serialize_entities = require("modules/gridworld/merge_map/serialize_entities"),
+	deserialize_entities = require("modules/gridworld/merge_map/deserialize_entities"),
 }

--- a/module/merge_map/prepare_chunks.lua
+++ b/module/merge_map/prepare_chunks.lua
@@ -1,0 +1,20 @@
+local function prepare_chunks(left_top, right_bottom)
+	local chunk_position_left_top = {math.floor(left_top[1] / 32), math.floor(left_top[2] / 32)}
+	local chunk_position_right_bottom = {math.floor(right_bottom[1] / 32), math.floor(right_bottom[2] / 32)}
+
+	for x = chunk_position_left_top[1], chunk_position_right_bottom[1] do
+		for y = chunk_position_left_top[2], chunk_position_right_bottom[2] do
+			-- Mark generation as complete
+			game.surfaces[1].set_chunk_generated_status({x, y}, defines.chunk_generated_status.entities)
+		end
+	end
+
+	-- Delete all entities in area in case anything was generated
+	local entities = game.surfaces[1].find_entities({left_top, right_bottom})
+	for _, entity in pairs(entities) do
+		entity.destroy()
+	end
+
+	rcon.print("Area prepared")
+end
+return prepare_chunks

--- a/module/merge_map/serialize_entities.lua
+++ b/module/merge_map/serialize_entities.lua
@@ -11,7 +11,7 @@ local function serialize_entities(area, surface)
 	local serialized_entities = {}
 	for _, entity in pairs(entities) do
 		if entity.valid then
-			local serialized_entity = universal_serializer.entity.serialize(entity)
+			local serialized_entity = universal_serializer.LuaEntity.serialize(entity)
 			table.insert(serialized_entities, serialized_entity)
 		end
 	end

--- a/module/merge_map/serialize_entities.lua
+++ b/module/merge_map/serialize_entities.lua
@@ -1,0 +1,22 @@
+local universal_serializer = require("modules/gridworld/universal_serializer/universal_serializer")
+
+--[[
+	Serialize entities within an area
+]]
+local function serialize_entities(area, surface)
+	if surface == nil then
+		surface = game.surfaces["nauvis"]
+	end
+	local entities = surface.find_entities_filtered({area = area})
+	local serialized_entities = {}
+	for _, entity in pairs(entities) do
+		if entity.valid then
+			local serialized_entity = universal_serializer.entity.serialize(entity)
+			table.insert(serialized_entities, serialized_entity)
+		end
+	end
+
+	rcon.print(game.table_to_json(serialized_entities))
+end
+
+return serialize_entities

--- a/module/merge_map/set_map_tile_data.lua
+++ b/module/merge_map/set_map_tile_data.lua
@@ -1,0 +1,57 @@
+local get_tile_colors = require("modules/gridworld/merge_map/get_tile_colors")
+
+local first = 256
+local second = 256^2
+local third = 256^3
+local function bytesToInt(b1, b2, b3, b4)
+	if b1 == nil or b2 == nil or b3 == nil or b4 == nil then
+		log("bytesToInt: nil value")
+		if b1 ~= nil then log("b1: " .. b1) end
+		if b2 ~= nil then log("b2: " .. b2) end
+		if b3 ~= nil then log("b3: " .. b3) end
+		if b4 ~= nil then log("b4: " .. b4) end
+		return 0
+	end
+	-- return (b1 * third) + (b2 * second) + (b3 * first) + b4 -- Big endian
+	return (b4 * third) + (b3 * second) + (b2 * first) + b1 -- Little endian
+end
+
+--[[ Receive map tiles from MapMergeRequestHandler and set them in the map. ]]
+local function set_map_tile_data(data)
+	local surface = game.surfaces["nauvis"]
+	-- Tiles are binary encoded as 4 bytes x, 4 bytes y, 1 byte ID
+
+	local tile_colors = get_tile_colors(false)
+	-- Create mapping of tile ID to tile name where name is the key in tile_colors
+	local tile_id_to_name = {}
+	local o = 1
+	for k, v in pairs(tile_colors) do
+		tile_id_to_name[o] = k
+		o = o + 1
+	end
+
+	local tiles = {}
+	for i = 1, #data, 9 do
+		-- Since this is running in Lua 5.2 string.unpack does not exist and we have to use string.byte instead
+		local tile = data:byte(i+8)
+		if tile ~= 0 and tile ~= nil then
+			local x = bytesToInt(data:byte(i, i+3))
+			local y = bytesToInt(data:byte(i+4, i+7))
+			local name = tile_id_to_name[tile]
+			if name == nil then
+				log("Tile ID " .. tile .. " not found in tile_colors")
+				log(data:sub(i, i+8))
+				log("x: " .. x .. " y: " .. y)
+				log(#data)
+			else
+				table.insert(tiles, {position = {x, y}, name = name})
+			end
+		end
+	end
+
+	-- Set the tiles
+	surface.set_tiles(tiles)
+	rcon.print("Set " .. #tiles .. " tiles")
+end
+
+return set_map_tile_data

--- a/module/merge_map/set_map_tile_data.lua
+++ b/module/merge_map/set_map_tile_data.lua
@@ -38,12 +38,8 @@ local function set_map_tile_data(data)
 			local x = bytesToInt(data:byte(i, i+3))
 			local y = bytesToInt(data:byte(i+4, i+7))
 			local name = tile_id_to_name[tile]
-			if name == nil then
-				log("Tile ID " .. tile .. " not found in tile_colors")
-				log(data:sub(i, i+8))
-				log("x: " .. x .. " y: " .. y)
-				log(#data)
-			else
+			-- TODO: Figure out why empty-ish tiles generate garbage data
+			if name ~= nil then
 				table.insert(tiles, {position = {x, y}, name = name})
 			end
 		end

--- a/module/universal_serializer/classes/LuaEntity_deserialize.lua
+++ b/module/universal_serializer/classes/LuaEntity_deserialize.lua
@@ -72,9 +72,13 @@ local function entity_deserialize(serialized_entity, is_already_delayed)
 	--[[ locomotive ]]
 	if entity_data.type == "locomotive" then
 		properties.snap_to_train_stop = false
-		-- TODO: use entity.train to serialize the schedule
 	end
 	--[[ logistic-container is not implemented ]]
+	if entity_data.type == "logistic-container" then
+		-- request_filters are mmb filters, not request slots
+		-- properties.request_filters = entity_data.request_filters
+		properties.request_from_buffers = entity_data.request_from_buffers
+	end
 	--[[ particle is not implemented ]]
 	--[[ artillery-flare is not implemented ]]
 	--[[ projectile is not implemented ]]
@@ -174,10 +178,24 @@ local function entity_deserialize(serialized_entity, is_already_delayed)
 		LuaTrain_deserialize(entity, entity_data.train)
 	end
 
+	-- Entity ghost again
+	if entity_data.type == "entity-ghost" then
+		properties.item_requests = entity_data.item_requests
+	end
+
 	--[[ Handle inventories ]]
 	for i = 1, 10 do
 		if entity_data.inventories[i] ~= nil then
 			clusterio_serialize.deserialize_inventory(entity.get_inventory(i), entity_data.inventories[i])
+		end
+	end
+
+	-- Set requester slots
+	if entity_data.request_slots ~= nil then
+		for i = 1, entity_data.request_slot_count do
+			if entity_data.request_slots[i] ~= nil then
+				entity.set_request_slot(entity_data.request_slots[i], i)
+			end
 		end
 	end
 

--- a/module/universal_serializer/classes/LuaEntity_deserialize.lua
+++ b/module/universal_serializer/classes/LuaEntity_deserialize.lua
@@ -109,6 +109,24 @@ local function entity_deserialize(serialized_entity, is_already_delayed)
 		entity.trains_limit = entity_data.trains_limit
 	end
 	if entity_data.control_behavior ~= nil then
+		log(entity_data.name)
+		log(serpent.block(entity_data.control_behavior))
+		---@param cb LuaGenericOnOffControlBehavior
+		local function LuaGenericOnOffControlBehavior_deserialize(cb)
+			cb.connect_to_logistic_network = entity_data.control_behavior.connect_to_logistic_network
+			log("1")
+			if entity_data.control_behavior.circuit_condition ~= nil then
+				log("2")
+				cb.circuit_condition = entity_data.control_behavior.circuit_condition
+			end
+			log("3")
+			if entity_data.control_behavior.logistic_condition ~= nil then
+				log("Setting logistic_condition")
+				log(serpent.block(entity_data.control_behavior.logistic_condition))
+				cb.logistic_condition = entity_data.control_behavior.logistic_condition
+			end
+			log("5")
+		end
 		if entity_data.control_behavior.object_name == "LuaTrainStopControlBehavior" then
 			---@class LuaTrainStopControlBehavior
 			local control_behavior = entity.get_or_create_control_behavior()
@@ -118,28 +136,36 @@ local function entity_deserialize(serialized_entity, is_already_delayed)
 			control_behavior.set_trains_limit = entity_data.control_behavior.set_trains_limit
 			control_behavior.read_trains_count = entity_data.control_behavior.read_trains_count
 			control_behavior.enable_disable = entity_data.control_behavior.enable_disable
-			control_behavior.stopped_train_signal = entity_data.control_behavior.stopped_train_signal
-			control_behavior.trains_count_signal = entity_data.control_behavior.trains_count_signal
-			control_behavior.trains_limit_signal = entity_data.control_behavior.trains_limit_signal
-			-- Shared with LuaGenericOnOffControlBehavior
-			control_behavior.connect_to_logistic_network = entity_data.control_behavior.connect_to_logistic_network
-			if entity_data.control_behavior.circuit_condition ~= nil then
-				control_behavior.circuit_condition = entity_data.control_behavior.circuit_condition
+			if entity_data.control_behavior.stopped_train_signal ~= nil then
+				control_behavior.stopped_train_signal = entity_data.control_behavior.stopped_train_signal
 			end
-			if entity_data.control_behavior.logistic_condition ~= nil then
-				control_behavior.logistic_condition = entity_data.control_behavior.logistic_condition
+			if entity_data.control_behavior.trains_count_signal ~= nil then
+				control_behavior.trains_count_signal = entity_data.control_behavior.trains_count_signal
 			end
+			if entity_data.control_behavior.trains_limit_signal ~= nil then
+				control_behavior.trains_limit_signal = entity_data.control_behavior.trains_limit_signal
+			end
+			-- Inhertited from LuaGenericOnOffControlBehavior
+			LuaGenericOnOffControlBehavior_deserialize(control_behavior)
+		end
+		if entity_data.control_behavior.object_name == "LuaInserterControlBehavior" then
+			---@class LuaInserterControlBehavior
+			local control_behavior = entity.get_or_create_control_behavior()
+			control_behavior.circuit_read_hand_contents = entity_data.control_behavior.circuit_read_hand_contents
+			control_behavior.circuit_mode_of_operation = entity_data.control_behavior.circuit_mode_of_operation
+			control_behavior.circuit_hand_read_mode = entity_data.control_behavior.circuit_hand_read_mode
+			control_behavior.circuit_set_stack_size = entity_data.control_behavior.circuit_set_stack_size
+			if entity_data.control_behavior.circuit_stack_control_signal ~= nil then
+				control_behavior.circuit_stack_control_signal = entity_data.control_behavior
+					.circuit_stack_control_signal
+			end
+			-- Inhertited from LuaGenericOnOffControlBehavior
+			LuaGenericOnOffControlBehavior_deserialize(control_behavior)
 		end
 		if entity_data.control_behavior.object_name == "LuaGenericOnOffControlBehavior" then
 			---@class LuaGenericOnOffControlBehavior
 			local control_behavior = entity.get_or_create_control_behavior()
-			control_behavior.connect_to_logistic_network = entity_data.control_behavior.connect_to_logistic_network
-			if entity_data.control_behavior.circuit_condition ~= nil then
-				control_behavior.circuit_condition = entity_data.control_behavior.circuit_condition
-			end
-			if entity_data.control_behavior.logistic_condition ~= nil then
-				control_behavior.logistic_condition = entity_data.control_behavior.logistic_condition
-			end
+			LuaGenericOnOffControlBehavior_deserialize(control_behavior)
 		end
 	end
 

--- a/module/universal_serializer/classes/LuaEntity_deserialize.lua
+++ b/module/universal_serializer/classes/LuaEntity_deserialize.lua
@@ -105,6 +105,12 @@ local function entity_deserialize(serialized_entity, is_already_delayed)
 		return nil
 	end
 
+	if entity_data.energy ~= nil then
+		entity.energy = entity_data.energy
+	end
+	if entity_data.temperature ~= nil then
+		entity.temperature = entity_data.temperature
+	end
 	if entity.supports_backer_name() then
 		entity.backer_name = entity_data.backer_name
 	end

--- a/module/universal_serializer/classes/LuaEntity_serialize.lua
+++ b/module/universal_serializer/classes/LuaEntity_serialize.lua
@@ -40,6 +40,25 @@ local function entity_serialize(entity)
 	end
 	if entity.type == "entity-ghost" then
 		entity_data.ghost_name = entity.ghost_name
+		entity_data.item_requests = entity.item_requests
+	end
+	if entity.type == "logistic-container" then
+		-- entity_data.request_filters = entity.request_filters -- Request_filters is not a property
+		-- Read request slots individually
+		local slot_count = entity.request_slot_count
+		if slot_count > 0 then
+			local request_slots = {}
+			for i = 1, slot_count do
+				local item_stack = entity.get_request_slot(i)
+				if item_stack ~= nil then
+					request_slots[i] = item_stack
+				end
+			end
+			entity_data.request_slots = request_slots
+			entity_data.request_slot_count = slot_count
+			-- This line crashes when read on a storage chest (any entity without request slots)
+			entity_data.request_from_buffers = entity.request_from_buffers
+		end
 	end
 	if entity.type == "item-entity" and entity.name == "item-on-ground" then
 		entity_data.stack = {

--- a/module/universal_serializer/classes/LuaEntity_serialize.lua
+++ b/module/universal_serializer/classes/LuaEntity_serialize.lua
@@ -1,8 +1,9 @@
 local clusterio_serialize = require("modules/clusterio/serialize")
-
+local LuaTrain_serialize = require("modules/gridworld/universal_serializer/classes/LuaTrain_serialize")
 --[[
 	Function to serialize an entity to a string.
 ]]
+---@param entity LuaEntity
 local function entity_serialize(entity)
 	local entity_data = {
 		surface = entity.surface.name,
@@ -76,6 +77,11 @@ local function entity_serialize(entity)
 			end
 		end
 		-- LuaCircuitNetwork (not implemented, needs red and green)
+	end
+
+	-- Trains
+	if entity.train ~= nil then
+		entity_data.train = LuaTrain_serialize(entity.train)
 	end
 
 	entity_data.inventories = {}

--- a/module/universal_serializer/classes/LuaEntity_serialize.lua
+++ b/module/universal_serializer/classes/LuaEntity_serialize.lua
@@ -54,8 +54,22 @@ local function entity_serialize(entity)
 	local control_behavior = entity.get_control_behavior()
 	if control_behavior ~= nil then
 		entity_data.control_behavior = {}
+		entity_data.control_behavior.object_name = control_behavior.object_name
+		---@param cb LuaGenericOnOffControlBehavior
+		local function LuaGenericOnOffControlBehavior_serialize(cb)
+			entity_data.control_behavior.connect_to_logistic_network = cb.connect_to_logistic_network
+			if cb.circuit_condition ~= nil then
+				entity_data.control_behavior.circuit_condition = {
+					condition = cb.circuit_condition.condition
+				}
+			end
+			if cb.logistic_condition ~= nil then
+				entity_data.control_behavior.logistic_condition = {
+					condition = cb.logistic_condition.condition
+				}
+			end
+		end
 		if control_behavior.object_name == "LuaTrainStopControlBehavior" then
-			entity_data.control_behavior.object_name = control_behavior.object_name
 			entity_data.control_behavior.send_to_train = control_behavior.send_to_train
 			entity_data.control_behavior.read_from_train = control_behavior.read_from_train
 			entity_data.control_behavior.read_stopped_train = control_behavior.read_stopped_train
@@ -65,16 +79,18 @@ local function entity_serialize(entity)
 			entity_data.control_behavior.stopped_train_signal = control_behavior.stopped_train_signal
 			entity_data.control_behavior.trains_count_signal = control_behavior.trains_count_signal
 			entity_data.control_behavior.trains_limit_signal = control_behavior.trains_limit_signal
+			LuaGenericOnOffControlBehavior_serialize(control_behavior)
 		end
-		if control_behavior.object_name == "LuaTrainStopControlBehavior" or control_behavior.object_name == "LuaGenericOnOffControlBehavior" then
-			entity_data.control_behavior.object_name = control_behavior.object_name
-			entity_data.control_behavior.connect_to_logistic_network = control_behavior.connect_to_logistic_network
-			if control_behavior.circuit_condition ~= nil then
-				entity_data.control_behavior.circuit_condition = { control_behavior.circuit_condition.condition }
-			end
-			if control_behavior.logistic_condition ~= nil then
-				entity_data.control_behavior.logistic_condition = { control_behavior.logistic_condition.condition }
-			end
+		if control_behavior.object_name == "LuaInserterControlBehavior" then
+			entity_data.control_behavior.circuit_read_hand_contents = control_behavior.circuit_read_hand_contents
+			entity_data.control_behavior.circuit_mode_of_operation = control_behavior.circuit_mode_of_operation
+			entity_data.control_behavior.circuit_hand_read_mode = control_behavior.circuit_hand_read_mode
+			entity_data.control_behavior.circuit_set_stack_size = control_behavior.circuit_set_stack_size
+			entity_data.control_behavior.circuit_stack_control_signal = control_behavior.circuit_stack_control_signal
+			LuaGenericOnOffControlBehavior_serialize(control_behavior)
+		end
+		if control_behavior.object_name == "LuaGenericOnOffControlBehavior" then
+			LuaGenericOnOffControlBehavior_serialize(control_behavior)
 		end
 		-- LuaCircuitNetwork (not implemented, needs red and green)
 	end

--- a/module/universal_serializer/classes/LuaEntity_serialize.lua
+++ b/module/universal_serializer/classes/LuaEntity_serialize.lua
@@ -14,6 +14,8 @@ local function entity_serialize(entity)
 		orientation = entity.orientation,
 		force = entity.force.name,
 		player = entity.last_user and entity.last_user.name or nil,
+		energy = entity.energy,
+		temperature = entity.temperature,
 	}
 	if entity.supports_backer_name() then
 		entity_data.backer_name = entity.backer_name

--- a/module/universal_serializer/classes/LuaTrain_deserialize.lua
+++ b/module/universal_serializer/classes/LuaTrain_deserialize.lua
@@ -1,0 +1,18 @@
+-- Deserializes a LuaTrain object.
+---@param entity LuaEntity
+---@param train_data table
+---@return LuaTrain
+local function LuaTrain_deserialize(entity, train_data)
+	local train = entity.train
+	if train == nil then
+		error("Failed to find train")
+	end
+
+	train.manual_mode = train_data.manual_mode
+	train.speed = train_data.speed
+	train.schedule = train_data.schedule
+
+	return train
+end
+
+return LuaTrain_deserialize

--- a/module/universal_serializer/classes/LuaTrain_serialize.lua
+++ b/module/universal_serializer/classes/LuaTrain_serialize.lua
@@ -1,0 +1,14 @@
+-- Serializes a LuaTrain object.
+---@param train LuaTrain
+---@return table
+local function LuaTrain_serialize(train)
+	local train_data = {
+		manual_mode = train.manual_mode,
+		speed = train.speed,
+		schedule = train.schedule,
+	}
+
+	return train_data
+end
+
+return LuaTrain_serialize

--- a/module/universal_serializer/entity.lua
+++ b/module/universal_serializer/entity.lua
@@ -1,10 +1,11 @@
 local clusterio_serialize = require("modules/clusterio/serialize")
--- local clusterio_serialize = serialize
+
+local entity_serializer = {}
 
 --[[
 	Function to serialize an entity to a string.
 ]]
-local function serialize_entity(entity)
+function entity_serializer.serialize(entity)
 	local entity_data = {
 		surface = entity.surface.name,
 		name = entity.name,
@@ -61,12 +62,11 @@ local function serialize_entity(entity)
 
 	return serpent.line(entity_data)
 end
-game.print(serialize_entity(game.player.selected))
 
 --[[
 	Function to deserialize an entity from a string.
 ]]
-local function deserialize_entity(serialized_entity)
+function entity_serializer.deserialize(serialized_entity)
 	local entity_data = loadstring("return " .. serialized_entity)()
 	local properties = {
 		name = entity_data.name,
@@ -152,4 +152,5 @@ local function deserialize_entity(serialized_entity)
 
 	return entity
 end
-deserialize_entity(serialize_entity(game.player.selected))
+
+return entity_serializer

--- a/module/universal_serializer/entity.lua
+++ b/module/universal_serializer/entity.lua
@@ -1,0 +1,155 @@
+--[[ local clusterio_serialize = require("modules/clusterio/serialize")]]
+local clusterio_serialize = serialize
+
+--[[
+	Function to serialize an entity to a string.
+]]
+local function serialize_entity(entity)
+	local entity_data = {
+		surface = entity.surface.name,
+		name = entity.name,
+		type = entity.type,
+		position = {entity.position.x + 10, entity.position.y},
+		direction = entity.direction,
+		orientation = entity.orientation,
+		force = entity.force.name,
+		player = entity.last_user and entity.last_user.name or nil,
+	}
+	if entity.supports_backer_name() then
+		entity_data.backer_name = entity.backer_name
+	end
+	if entity.type == "entity-ghost" then
+		entity_data.ghost_name = entity.ghost_name
+		entity_data.time_to_live = entity.time_to_live --[[ Applies to ghost, combat robot, highlight box, smoke with trigger and sticker ]]
+	end
+	if entity.type == "unit" then
+		entity_data.unit_number = entity.unit_number
+	end
+	if entity.type == "assembling-machine" then
+		entity_data.recipe = entity.get_recipe() and entity.get_recipe().name
+	end
+	if entity.type == "container" then
+		entity_data.supports_bar = entity.get_inventory(defines.inventory.chest).supports_bar()
+		if entity_data.supports_bar then
+			entity_data.bar = entity.get_inventory(defines.inventory.chest).get_bar()
+		end
+	end
+	if entity.type == "cliff" then
+		entity_data.cliff_orientation = entity.cliff_orientation
+	end
+	if entity.type == "entity-ghost" then
+		entity_data.ghost_name = entity.ghost_name
+	end
+	if entity.type == "item-entity" and entity.name == "item-on-ground" then
+		entity_data.stack = {
+			name = entity.stack.name,
+			count = entity.stack.count,
+		}
+	end
+	if entity.type == "train-stop" then
+		entity_data.trains_limit = entity.trains_limit
+	end
+
+	entity_data.inventories = {}
+	--[[ Handle inventories ]]
+	--[[ Inventories are indexed from 1 to n, we don't care about their names. ]]
+	for i = 1, 10 do
+		if entity.get_inventory(i) ~= nil then
+			entity_data.inventories[i] = clusterio_serialize.serialize_inventory(entity.get_inventory(i))
+		end
+	end
+
+	return serpent.line(entity_data)
+end
+game.print(serialize_entity(game.player.selected))
+
+--[[
+	Function to deserialize an entity from a string.
+]]
+local function deserialize_entity(serialized_entity)
+	local entity_data = loadstring("return " .. serialized_entity)()
+	local properties = {
+		name = entity_data.name,
+		position = entity_data.position,
+		direction = entity_data.direction,
+		orientation = entity_data.orientation,
+		force = entity_data.force,
+		--[[ target ]]
+		--[[ source ]]
+		player = entity_data.player,
+		raise_build = true,
+		create_build_effect_smoke = false,
+		spawn_decorations = true,
+		move_stuck_players = true,
+		stack = {count = 1, name = "tank"},
+	}
+	--[[ assembling-machine ]]
+	if entity_data.type == "assembling-machine" then
+		properties.recipe = entity_data.recipe
+	end
+	--[[ beam is not implemented ]]
+	--[[ stream is not implemented ]]
+	--[[ container ]]
+	if entity_data.type == "container" then
+		properties.bar = entity_data.supports_bar and entity_data.bar
+	end
+	--[[ cliff ]]
+	if entity_data.type == "cliff" then
+		properties.cliff_orientation = entity_data.cliff_orientation
+	end
+	--[[ flying-text is not implemented ]]
+	--[[ entity-ghost ]]
+	if entity_data.type == "entity-ghost" then
+		properties.inner_name = entity_data.ghost_name
+		properties.expires = entity_data.time_to_live
+	end
+	--[[ fire is not implemented ]]
+	--[[ inserter is not implemented ]]
+	--[[ item-entity is not implemented ]]
+	--[[ item-request-proxy is not implemented ]]
+	--[[ rolling-stock is not implemented ]]
+	--[[ locomotive ]]
+	if entity_data.type == "locomotive" then
+		properties.snap_to_train_stop = false
+		-- TODO: use entity.train to serialize the schedule
+	end
+	--[[ logistic-container is not implemented ]]
+	--[[ particle is not implemented ]]
+	--[[ artillery-flare is not implemented ]]
+	--[[ projectile is not implemented ]]
+	--[[ artillery-projectile is not implemented ]]
+	--[[ resource is not implemented ]]
+	--[[ underground-belt is not implemented ]]
+	--[[ programmable-speaker is not implemented ]]
+	--[[ character-corpse is not implemented ]]
+	--[[ highlight-box is not implemented ]]
+	--[[ speech-bubble is not implemented ]]
+	--[[ simple-entity-with-owner is not implemented ]]
+	--[[ simple-entity-with-force is not implemented ]]
+	--[[ item-on-ground ]]
+	if entity_data.type == "item-entity" and entity_data.name == "item-on-ground" then
+		--[[ create_entity.stack is undocumented but it exists ]]
+		--[[ TODO: Use full item stack, including aux information such as spidertron contents and blueprints ]]
+		properties.stack = entity_data.stack
+	end
+
+	local entity = game.surfaces[entity_data.surface].create_entity(properties)
+
+	if entity.supports_backer_name() then
+		entity.backer_name = entity_data.backer_name
+	end
+	--[[ train-stop ]]
+	if entity_data.type == "train-stop" then
+		entity.trains_limit = entity_data.trains_limit
+	end
+
+	--[[ Handle inventories ]]
+	for i = 1, 10 do
+		if entity_data.inventories[i] ~= nil then
+			clusterio_serialize.deserialize_inventory(entity.get_inventory(i), entity_data.inventories[i])
+		end
+	end
+
+	return entity
+end
+deserialize_entity(serialize_entity(game.player.selected))

--- a/module/universal_serializer/entity.lua
+++ b/module/universal_serializer/entity.lua
@@ -1,5 +1,5 @@
---[[ local clusterio_serialize = require("modules/clusterio/serialize")]]
-local clusterio_serialize = serialize
+local clusterio_serialize = require("modules/clusterio/serialize")
+-- local clusterio_serialize = serialize
 
 --[[
 	Function to serialize an entity to a string.

--- a/module/universal_serializer/entity_deserialize.lua
+++ b/module/universal_serializer/entity_deserialize.lua
@@ -22,7 +22,6 @@ local function entity_deserialize(serialized_entity)
 		create_build_effect_smoke = false,
 		spawn_decorations = true,
 		move_stuck_players = true,
-		stack = {count = 1, name = "tank"},
 	}
 	if player ~= nil then -- Prevent crash if player has never joined this server
 		properties.player = player
@@ -88,6 +87,40 @@ local function entity_deserialize(serialized_entity)
 	--[[ train-stop ]]
 	if entity_data.type == "train-stop" then
 		entity.trains_limit = entity_data.trains_limit
+	end
+	if entity_data.control_behavior ~= nil then
+		if entity_data.control_behavior.object_name == "LuaTrainStopControlBehavior" then
+			---@class LuaTrainStopControlBehavior
+			local control_behavior = entity.get_or_create_control_behavior()
+			control_behavior.send_to_train = entity_data.control_behavior.send_to_train
+			control_behavior.read_from_train = entity_data.control_behavior.read_from_train
+			control_behavior.read_stopped_train = entity_data.control_behavior.read_stopped_train
+			control_behavior.set_trains_limit = entity_data.control_behavior.set_trains_limit
+			control_behavior.read_trains_count = entity_data.control_behavior.read_trains_count
+			control_behavior.enable_disable = entity_data.control_behavior.enable_disable
+			control_behavior.stopped_train_signal = entity_data.control_behavior.stopped_train_signal
+			control_behavior.trains_count_signal = entity_data.control_behavior.trains_count_signal
+			control_behavior.trains_limit_signal = entity_data.control_behavior.trains_limit_signal
+			-- Shared with LuaGenericOnOffControlBehavior
+			control_behavior.connect_to_logistic_network = entity_data.control_behavior.connect_to_logistic_network
+			if entity_data.control_behavior.circuit_condition ~= nil then
+				control_behavior.circuit_condition = entity_data.control_behavior.circuit_condition
+			end
+			if entity_data.control_behavior.logistic_condition ~= nil then
+				control_behavior.logistic_condition = entity_data.control_behavior.logistic_condition
+			end
+		end
+		if entity_data.control_behavior.object_name == "LuaGenericOnOffControlBehavior" then
+			---@class LuaGenericOnOffControlBehavior
+			local control_behavior = entity.get_or_create_control_behavior()
+			control_behavior.connect_to_logistic_network = entity_data.control_behavior.connect_to_logistic_network
+			if entity_data.control_behavior.circuit_condition ~= nil then
+				control_behavior.circuit_condition = entity_data.control_behavior.circuit_condition
+			end
+			if entity_data.control_behavior.logistic_condition ~= nil then
+				control_behavior.logistic_condition = entity_data.control_behavior.logistic_condition
+			end
+		end
 	end
 
 	--[[ Handle inventories ]]

--- a/module/universal_serializer/entity_serialize.lua
+++ b/module/universal_serializer/entity_serialize.lua
@@ -1,0 +1,64 @@
+local clusterio_serialize = require("modules/clusterio/serialize")
+
+--[[
+	Function to serialize an entity to a string.
+]]
+local function entity_serialize(entity)
+	local entity_data = {
+		surface = entity.surface.name,
+		name = entity.name,
+		type = entity.type,
+		position = {entity.position.x, entity.position.y},
+		direction = entity.direction,
+		orientation = entity.orientation,
+		force = entity.force.name,
+		player = entity.last_user and entity.last_user.name or nil,
+	}
+	if entity.supports_backer_name() then
+		entity_data.backer_name = entity.backer_name
+	end
+	if entity.type == "entity-ghost" then
+		entity_data.ghost_name = entity.ghost_name
+		entity_data.time_to_live = entity.time_to_live --[[ Applies to ghost, combat robot, highlight box, smoke with trigger and sticker ]]
+	end
+	if entity.type == "unit" then
+		entity_data.unit_number = entity.unit_number
+	end
+	if entity.type == "assembling-machine" then
+		entity_data.recipe = entity.get_recipe() and entity.get_recipe().name
+	end
+	if entity.type == "container" then
+		entity_data.supports_bar = entity.get_inventory(defines.inventory.chest).supports_bar()
+		if entity_data.supports_bar then
+			entity_data.bar = entity.get_inventory(defines.inventory.chest).get_bar()
+		end
+	end
+	if entity.type == "cliff" then
+		entity_data.cliff_orientation = entity.cliff_orientation
+	end
+	if entity.type == "entity-ghost" then
+		entity_data.ghost_name = entity.ghost_name
+	end
+	if entity.type == "item-entity" and entity.name == "item-on-ground" then
+		entity_data.stack = {
+			name = entity.stack.name,
+			count = entity.stack.count,
+		}
+	end
+	if entity.type == "train-stop" then
+		entity_data.trains_limit = entity.trains_limit
+	end
+
+	entity_data.inventories = {}
+	--[[ Handle inventories ]]
+	--[[ Inventories are indexed from 1 to n, we don't care about their names. ]]
+	for i = 1, 10 do
+		if entity.get_inventory(i) ~= nil then
+			entity_data.inventories[i] = clusterio_serialize.serialize_inventory(entity.get_inventory(i))
+		end
+	end
+
+	return serpent.line(entity_data)
+end
+
+return entity_serialize

--- a/module/universal_serializer/entity_serialize.lua
+++ b/module/universal_serializer/entity_serialize.lua
@@ -8,7 +8,7 @@ local function entity_serialize(entity)
 		surface = entity.surface.name,
 		name = entity.name,
 		type = entity.type,
-		position = {entity.position.x, entity.position.y},
+		position = { entity.position.x, entity.position.y },
 		direction = entity.direction,
 		orientation = entity.orientation,
 		force = entity.force.name,
@@ -19,7 +19,8 @@ local function entity_serialize(entity)
 	end
 	if entity.type == "entity-ghost" then
 		entity_data.ghost_name = entity.ghost_name
-		entity_data.time_to_live = entity.time_to_live --[[ Applies to ghost, combat robot, highlight box, smoke with trigger and sticker ]]
+		entity_data.time_to_live = entity
+			.time_to_live --[[ Applies to ghost, combat robot, highlight box, smoke with trigger and sticker ]]
 	end
 	if entity.type == "unit" then
 		entity_data.unit_number = entity.unit_number
@@ -47,6 +48,34 @@ local function entity_serialize(entity)
 	end
 	if entity.type == "train-stop" then
 		entity_data.trains_limit = entity.trains_limit
+	end
+	-- Circuit connection
+	local control_behavior = entity.get_control_behavior()
+	if control_behavior ~= nil then
+		entity_data.control_behavior = {}
+		if control_behavior.object_name == "LuaTrainStopControlBehavior" then
+			entity_data.control_behavior.object_name = control_behavior.object_name
+			entity_data.control_behavior.send_to_train = control_behavior.send_to_train
+			entity_data.control_behavior.read_from_train = control_behavior.read_from_train
+			entity_data.control_behavior.read_stopped_train = control_behavior.read_stopped_train
+			entity_data.control_behavior.set_trains_limit = control_behavior.set_trains_limit
+			entity_data.control_behavior.read_trains_count = control_behavior.read_trains_count
+			entity_data.control_behavior.enable_disable = control_behavior.enable_disable
+			entity_data.control_behavior.stopped_train_signal = control_behavior.stopped_train_signal
+			entity_data.control_behavior.trains_count_signal = control_behavior.trains_count_signal
+			entity_data.control_behavior.trains_limit_signal = control_behavior.trains_limit_signal
+		end
+		if control_behavior.object_name == "LuaTrainStopControlBehavior" or control_behavior.object_name == "LuaGenericOnOffControlBehavior" then
+			entity_data.control_behavior.object_name = control_behavior.object_name
+			entity_data.control_behavior.connect_to_logistic_network = control_behavior.connect_to_logistic_network
+			if control_behavior.circuit_condition ~= nil then
+				entity_data.control_behavior.circuit_condition = { control_behavior.circuit_condition.condition }
+			end
+			if control_behavior.logistic_condition ~= nil then
+				entity_data.control_behavior.logistic_condition = { control_behavior.logistic_condition.condition }
+			end
+		end
+		-- LuaCircuitNetwork (not implemented, needs red and green)
 	end
 
 	entity_data.inventories = {}

--- a/module/universal_serializer/events/on_tick.lua
+++ b/module/universal_serializer/events/on_tick.lua
@@ -1,0 +1,17 @@
+local LuaEntity_deserialize = require("modules/gridworld/universal_serializer/classes/LuaEntity_deserialize")
+
+local function on_tick()
+	if global.delayed_entities_tick ~= nil
+		and global.delayed_entities_tick <= game.tick
+		and #(global.delayed_entities or {}) > 0
+	then
+		-- Attempt to deserialize delayed entities
+		for i = #global.delayed_entities, 1, -1 do
+			local entity = global.delayed_entities[i]
+			LuaEntity_deserialize(entity, true)
+			table.remove(global.delayed_entities, i)
+		end
+	end
+end
+
+return on_tick

--- a/module/universal_serializer/universal_serializer.lua
+++ b/module/universal_serializer/universal_serializer.lua
@@ -1,0 +1,6 @@
+return {
+	entity = {
+		serialize = require("modules/gridworld/universal_serializer/entity_serialize"),
+		deserialize = require("modules/gridworld/universal_serializer/entity_deserialize"),
+	}
+}

--- a/module/universal_serializer/universal_serializer.lua
+++ b/module/universal_serializer/universal_serializer.lua
@@ -1,6 +1,13 @@
 return {
-	entity = {
-		serialize = require("modules/gridworld/universal_serializer/entity_serialize"),
-		deserialize = require("modules/gridworld/universal_serializer/entity_deserialize"),
+	events = {
+		on_tick = require("modules/gridworld/universal_serializer/events/on_tick"),
+	},
+	LuaEntity = {
+		serialize = require("modules/gridworld/universal_serializer/classes/LuaEntity_serialize"),
+		deserialize = require("modules/gridworld/universal_serializer/classes/LuaEntity_deserialize"),
+	},
+	LuaTrain = {
+		serialize = require("modules/gridworld/universal_serializer/classes/LuaTrain_serialize"),
+		deserialize = require("modules/gridworld/universal_serializer/classes/LuaTrain_deserialize"),
 	}
 }

--- a/src/mapview/constants.js
+++ b/src/mapview/constants.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+	TILE_SIZE: 512,
+};

--- a/src/mapview/tileDataEventHandler.js
+++ b/src/mapview/tileDataEventHandler.js
@@ -5,7 +5,8 @@ sharp.cache(false);
 const sleep = require("../util/sleep");
 const worldPositionToInstance = require("../worldgen/util/worldPositionToInstance");
 
-const TILE_SIZE = 512;
+const { TILE_SIZE } = require("./constants");
+
 const fileLocks = {}; // Used to prevent multiple writes to the same file
 const updates = new Map();
 

--- a/src/mapview/tileDataEventHandler.js
+++ b/src/mapview/tileDataEventHandler.js
@@ -9,7 +9,13 @@ const TILE_SIZE = 512;
 const fileLocks = {}; // Used to prevent multiple writes to the same file
 const updates = new Map();
 
+// eslint-disable-next-line complexity
 module.exports = async function tileDataEventHandler({ type, data, size, position, instance_id, grid_id, layer }) {
+	// Check if instance is a grid square
+	if (!this.controller.instances.get(instance_id).config.get("gridworld.is_grid_square")) {
+		return;
+	}
+
 	// console.log(type, size, position);
 	// Image tiles are 512x512 pixels arranged in a grid, starting at 0,0
 	if (type === "pixels") {

--- a/src/request_handlers/startMapMergeRequestHandler.js
+++ b/src/request_handlers/startMapMergeRequestHandler.js
@@ -3,6 +3,7 @@ const lib = require("@clusterio/lib");
 
 const assignInstance = require("../worldgen/assignInstance");
 const createSave = require("../worldgen/createSave");
+const { InstanceInfo } = require("@clusterio/controller");
 
 module.exports = async function startMapMergeRequestHandler(message) {
 	// message === {
@@ -17,7 +18,7 @@ module.exports = async function startMapMergeRequestHandler(message) {
 	instanceConfig.set("instance.name", name);
 
 	let instanceId = instanceConfig.get("instance.id");
-	if (plugin.controller.instances.has(instanceId)) {
+	if (this.controller.instances.has(instanceId)) {
 		throw new lib.RequestError(`Instance with ID ${instanceId} already exists`);
 	}
 

--- a/src/request_handlers/startMapMergeRequestHandler.js
+++ b/src/request_handlers/startMapMergeRequestHandler.js
@@ -1,0 +1,83 @@
+"use strict";
+const lib = require("@clusterio/lib");
+
+const assignInstance = require("../worldgen/assignInstance");
+const createSave = require("../worldgen/createSave");
+
+module.exports = async function startMapMergeRequestHandler(message) {
+	// message === {
+	// grid_id: "grid_id",
+	// host_id: "host_id",
+	// }
+
+	// Create a new instance on the target host
+	const name = `Map Merge ${message.grid_id}`;
+	this.logger.info(`Creating instance for map merging ${name}`);
+	let instanceConfig = new lib.InstanceConfig("controller");
+	instanceConfig.set("instance.name", name);
+
+	let instanceId = instanceConfig.get("instance.id");
+	if (plugin.controller.instances.has(instanceId)) {
+		throw new lib.RequestError(`Instance with ID ${instanceId} already exists`);
+	}
+
+	// Add common settings for the Factorio server
+	let settings = {
+		...instanceConfig.get("factorio.settings"),
+
+		"name": `${this.controller.config.get("controller.name")} - ${name}`,
+		"description": `Clusterio instance for ${this.controller.config.get("controller.name")}`,
+		"tags": ["clusterio", "gridworld"],
+		"visibility": { "public": true, "lan": true },
+		"require_user_verification": true,
+		"auto_pause": false,
+	};
+	instanceConfig.set("factorio.settings", settings);
+
+	const mergeTargetInstance = new InstanceInfo(instanceConfig, "unassigned", undefined, Date.now());
+	this.controller.instances.set(instanceId, mergeTargetInstance);
+	await lib.invokeHook(this.controller.plugins, "onInstanceStatusChanged", mergeTargetInstance, null);
+	this.controller.addInstanceHooks(mergeTargetInstance);
+
+	// Assign instance to a host
+	await assignInstance(this, instanceId, message.host_id);
+
+	// Create savefile
+	await createSave(
+		this,
+		instanceId,
+		this.controller.config.get("gridworld.gridworld_seed"),
+		this.controller.config.get("gridworld.gridworld_map_exchange_string")
+	);
+
+	// Start instance
+	await this.controller.sendTo({ instanceId }, new lib.InstanceStartRequest());
+
+	// Get instances with the same grid_id
+	const instances = this.controller.instances.filter(instance => instance.config.get("gridworld.grid_id") === message.grid_id);
+	for (let instance of instances) {
+		// Generate chunks in target area on merge target
+		const grid_x_size = instance.config.get("gridworld.grid_x_size");
+		const grid_y_size = instance.config.get("gridworld.grid_y_size");
+		const grid_x_position = instance.config.get("gridworld.grid_x_position");
+		const grid_y_position = instance.config.get("gridworld.grid_y_position");
+		const leftTop = [grid_x_position * grid_x_size, grid_y_position * grid_y_size];
+		const rightBottom = [(grid_x_position + 1) * grid_x_size, (grid_y_position + 1) * grid_y_size];
+		const command = `/c gridworld.merge_map.prepare_chunks({${leftTop[0]}, ${leftTop[1]}}, {${rightBottom[0]}, ${rightBottom[1]})`;
+		const status = await this.controller.sendTo({ instanceId }, new lib.InstanceSendRconRequest(command));
+		this.logger.info(`Prepare chunks status for ${instance.name}: ${status}`);
+	}
+
+	for (let instance of instances) {
+		// Ensure the instance is running
+		if (instance.status === "stopped") {
+			this.logger.info(`Starting instance ${instance.name}`);
+			await this.controller.sendTo({ instanceId: instance.id }, new lib.InstanceStartRequest());
+		}
+
+		// Perform tile dump
+
+		// Perform entity dump
+
+	}
+};

--- a/src/request_handlers/startMapMergeRequestHandler.js
+++ b/src/request_handlers/startMapMergeRequestHandler.js
@@ -1,10 +1,15 @@
 "use strict";
+const path = require("path");
+const fs = require("fs-extra");
+const sharp = require("sharp");
+
 const lib = require("@clusterio/lib");
 
 const assignInstance = require("../worldgen/assignInstance");
 const createSave = require("../worldgen/createSave");
 const { InstanceInfo } = require("@clusterio/controller");
 const mapFilter = require("../util/mapFilter");
+const { TILE_SIZE } = require("../mapview/constants");
 
 module.exports = async function startMapMergeRequestHandler(message) {
 	// message === {
@@ -75,14 +80,81 @@ module.exports = async function startMapMergeRequestHandler(message) {
 		this.logger.info(`Prepare chunks status for ${instance.config.get("instance.name")}: ${status}`);
 	}
 
+	// Set tiles using the map tiles stored on the controller
+	// Get tile colors from the instance
+	const tileColors = JSON.parse(
+		await this.controller.sendTo({ instanceId }, new lib.InstanceSendRconRequest("/c gridworld.merge_map.get_tile_colors()"))
+	);
+	const tileColorNames = Object.keys(tileColors);
+
+	// Get map tile files
+	const files = await fs.readdir(path.resolve(
+		this.controller.config.get("controller.database_directory"),
+		this.controller.config.get("gridworld.tiles_directory")
+	));
+	// Set tiles using the map tiles stored on the controller
+	for (let filename of files.filter(file => file.endsWith(".png") && file.startsWith("tiles_"))) {
+		const mapTile = await sharp(path.resolve(
+			this.controller.config.get("controller.database_directory"),
+			this.controller.config.get("gridworld.tiles_directory"),
+			filename
+		))
+			.raw()
+			.toBuffer();
+
+		let mapTileData = Buffer.alloc(TILE_SIZE * TILE_SIZE * 9); // 4 bytes x, 4 bytes y, 1 byte tile index
+		for (let i = 0; i < mapTile.length; i += 4) {
+			// Get position in map tile
+			const x = (i / 4) % TILE_SIZE;
+			const y = Math.floor((i / 4) / TILE_SIZE);
+			// Get world position
+			const world_x = x + parseInt(filename.match(/x(-?\d+)/)[1], 10) * TILE_SIZE;
+			const world_y = y + parseInt(filename.match(/y(-?\d+)/)[1], 10) * TILE_SIZE;
+
+			const color = {
+				r: mapTile[i],
+				g: mapTile[i + 1],
+				b: mapTile[i + 2],
+				a: mapTile[i + 3],
+			};
+			// Ignore transparent pixels
+			if (color.a !== 0) {
+				// Find the same color in the tileColors
+				const tileName = tileColorNames.find(tilename => {
+					const tileColor = tileColors[tilename];
+					return color.r === tileColor.r && color.g === tileColor.g && color.b === tileColor.b;
+				});
+				if (tileName !== undefined) {
+					const offset = (i / 4) * 9;
+
+					// Convert world_x (32bit int) to buffer
+					mapTileData.writeInt32LE(world_x, offset);
+
+					// Convert world_y (32bit int) to buffer
+					mapTileData.writeInt32LE(world_y, offset + 4);
+
+					// Get tile name index
+					const tileIndex = tileColorNames.indexOf(tileName) + 1; // 1 indexed because Lua
+					mapTileData.writeUInt8(tileIndex, offset + 8);
+				} else {
+					this.logger.warn(`Could not find tile color for pixel at ${world_x}, ${world_y} color ${color.r}, ${color.g}, ${color.b}`);
+				}
+			}
+		}
+
+		// Send map tile data to the merge target
+		// Make sure the last character of mapTileData is not ] (decimal 93, 5D hex) or it will error
+		const command = `/sc gridworld.merge_map.set_map_tile_data([========[${mapTileData.toString()}]========])`;
+		const status = await this.controller.sendTo({ instanceId }, new lib.InstanceSendRconRequest(command));
+		this.logger.info(`Set map tile data status for ${filename}: ${status}`);
+	}
+
 	for (let instance of instances) {
 		// Ensure the instance is running
 		if (instance.status === "stopped") {
 			this.logger.info(`Starting instance ${instance.name}`);
 			await this.controller.sendTo({ instanceId: instance.id }, new lib.InstanceStartRequest());
 		}
-
-		// Perform tile dump
 
 		// Perform entity dump
 

--- a/src/request_handlers/updateEdgeTransportEdgesRequestHandler.js
+++ b/src/request_handlers/updateEdgeTransportEdgesRequestHandler.js
@@ -4,12 +4,23 @@ const mapFind = require("../util/mapFind");
 const getEdges = require("../worldgen/getEdges");
 const { edge_target_position_offsets } = require("../worldgen/factionGrid/edge_target_position_offsets");
 
+/**
+ * Update edge transports edges for a grid square instance
+ * @param {object} message Message as defined by UpdateEdgeTransportEdges
+ * @param {object} message.data - The message data
+ * @param {number} message.data.instance_id - The instance ID of the instance to update edge transports for
+ */
 module.exports = async function updateEdgeTransportsEdges(message) {
-	// message.data === {
-	// instance_id: instance_id,
-	// }
-
 	const instance = this.controller.instances.get(message.data.instance_id);
+
+	if (!instance) {
+		this.logger.error(`Instance ${message.data.instance_id} not found`);
+		return;
+	}
+	if (!instance.config.get("gridworld.is_grid_square")) {
+		return;
+	}
+
 	const x = instance.config.get("gridworld.grid_x_position");
 	const y = instance.config.get("gridworld.grid_y_position");
 	const grid_id = instance.config.get("gridworld.grid_id");

--- a/src/worldgen/createInstance.js
+++ b/src/worldgen/createInstance.js
@@ -26,7 +26,7 @@ module.exports = async function createInstance(plugin, name, x, y, x_size, y_siz
 
 		"name": `${plugin.controller.config.get("controller.name")} - ${name}`,
 		"description": `Clusterio instance for ${plugin.controller.config.get("controller.name")}`,
-		"tags": ["clusterio"],
+		"tags": ["clusterio", "gridworld"],
 		"max_players": 0,
 		"visibility": { "public": true, "lan": true },
 		"username": "",

--- a/src/worldgen/createInstance.js
+++ b/src/worldgen/createInstance.js
@@ -6,6 +6,7 @@ module.exports = async function createInstance(plugin, name, x, y, x_size, y_siz
 	plugin.logger.info("Creating instance", name);
 	let instanceConfig = new lib.InstanceConfig("controller");
 	instanceConfig.set("instance.name", name);
+	instanceConfig.set("gridworld.is_grid_square", true);
 	instanceConfig.set("gridworld.grid_id", grid_id);
 	instanceConfig.set("gridworld.grid_x_position", x);
 	instanceConfig.set("gridworld.grid_y_position", y);

--- a/src/worldgen/factionGrid/createFactionGrid.js
+++ b/src/worldgen/factionGrid/createFactionGrid.js
@@ -13,5 +13,6 @@ module.exports = async function createFactionGrid({
 	let grid_id = lobbyInstance.config.get("gridworld.grid_id");
 	return {
 		grid_id,
+		lobby_server: lobbyInstance.config.get("instance.id"),
 	};
 };

--- a/src/worldgen/util/worldPositionToInstance.js
+++ b/src/worldgen/util/worldPositionToInstance.js
@@ -11,6 +11,10 @@ function worldPositionToInstance(x, y, grid_id, instances) {
 	const grid_instances = mapFilter(instances, instance => instance.config.get("gridworld.grid_id") === grid_id);
 	const lobby_server = mapFind(grid_instances, instance => instance.config.get("gridworld.is_lobby_server"));
 
+	if (!lobby_server) {
+		throw new Error(`No lobby server found for grid_id ${grid_id}`);
+	}
+
 	const grid_x_size = lobby_server.config.get("gridworld.grid_x_size");
 	const grid_y_size = lobby_server.config.get("gridworld.grid_y_size");
 

--- a/web/index.jsx
+++ b/web/index.jsx
@@ -6,6 +6,7 @@ import OverviewPage from "./pages/OverviewPage";
 import CreateGridworldPage from "./pages/CreateGridworldPage";
 import FactionsPage from "./pages/FactionsPage";
 import FactionViewPage from "./pages/FactionViewPage";
+import MergeMapPage from "./pages/MergeMapPage";
 import messages from "../messages";
 
 export class WebPlugin extends BaseWebPlugin {
@@ -31,17 +32,25 @@ export class WebPlugin extends BaseWebPlugin {
 				path: "/gridworld/factions/:faction_id/view",
 				content: <FactionViewPage />,
 			},
+			{
+				path: "/gridworld/merge_map",
+				permission: "gridworld.merge.start",
+				content: <MergeMapPage />,
+			},
 		];
 		this.playerPositions = new Map();
 		this.factions = new Map();
+		this.gridworlds = new Map();
 		this.updateHandlers = new Set();
 		this.updateHandlerCounts = {
 			player_position: 0,
 			faction_list: 0,
+			gridworlds: 0,
 		};
 
 		this.control.handle(messages.PlayerPosition, this.playerPositionEventHandler.bind(this));
 		this.control.handle(messages.FactionUpdate, this.factionUpdateEventHandler.bind(this));
+		this.control.handle(messages.GridworldUpdate, this.gridworldUpdateEventHandler.bind(this));
 	}
 
 	onControllerConnectionEvent(event) {
@@ -62,6 +71,14 @@ export class WebPlugin extends BaseWebPlugin {
 		this.updateHandlers.forEach(handler => {
 			if (handler.type === "faction_list") {
 				handler.callback(message.faction);
+			}
+		});
+	}
+
+	async gridworldUpdateEventHandler(message) {
+		this.updateHandlers.forEach(handler => {
+			if (handler.type === "gridworlds") {
+				handler.callback(message);
 			}
 		});
 	}
@@ -96,13 +113,17 @@ export class WebPlugin extends BaseWebPlugin {
 		this.control.send(new messages.SetWebSubscription({
 			player_position: this.updateHandlerCounts["player_position"] > 0,
 			faction_list: this.updateHandlerCounts["faction_list"] > 0,
+			gridworlds: this.updateHandlerCounts["gridworlds"] > 0,
 		})).catch(notifyErrorHandler("Error subscribing to event updates"));
 
 		if (this.updateHandlerCounts["player_position"] === 0) {
 			this.playerPositions.clear();
 		}
 		if (this.updateHandlerCounts["faction_list"] === 0) {
-			this.factions.length = 0;
+			this.factions.clear();
+		}
+		if (this.updateHandlerCounts["gridworlds"] === 0) {
+			this.gridworlds.clear();
 		}
 	}
 }

--- a/web/pages/MergeMapPage.jsx
+++ b/web/pages/MergeMapPage.jsx
@@ -1,0 +1,54 @@
+import { useContext } from "react";
+import { PageHeader, PageLayout, useHosts, ControlContext } from "@clusterio/web_ui";
+import { Form, Button, Select } from "antd";
+import useGridworlds from "../providers/useGridworlds";
+import gridworld from "../..";
+import messages from "../../messages";
+
+export default function MergeMapPage() {
+	const control = useContext(ControlContext);
+	const [hosts] = useHosts();
+	const gridworlds = useGridworlds(control);
+
+	return <PageLayout nav={[{ name: "Gridworld", path: "/gridworld" }, { name: "merge_map" }]}>
+		<PageHeader
+			className="site-page-header"
+			title="Merge map"
+		/>
+		<Form
+			onFinish={async values => {
+				await control.send(new messages.StartMapMerge({
+					host_id: values.host_id,
+					grid_id: values.grid_id,
+				}));
+			}}
+		>
+			<Form.Item
+				label="Host to use for merge"
+				name="host_id"
+			>
+				<Select>
+					{[...hosts?.keys()]
+						.map(key => hosts.get(key))
+						.map(host => <Select.Option key={host.id} value={host.id}>{host.name}</Select.Option>)}
+				</Select>
+			</Form.Item>
+			<Form.Item
+				label="Grid ID to merge"
+				name="grid_id"
+			>
+				<Select>
+					{[...gridworlds?.keys()]
+						.map(key => gridworlds.get(key))
+						.map(grid => <Select.Option key={`grid${grid.id}`} value={grid.id}>{grid.name_prefix}</Select.Option>)}
+				</Select>
+			</Form.Item>
+
+			<Form.Item>
+				<Button type="primary" htmlType="submit">
+					Merge
+				</Button>
+			</Form.Item>
+		</Form>
+	</PageLayout>;
+};

--- a/web/pages/OverviewPage.jsx
+++ b/web/pages/OverviewPage.jsx
@@ -49,6 +49,8 @@ function OverviewPage() {
 					</Button>
 				</Popconfirm>,
 				<RefreshTileDataButton key="refresh" />,
+				account.hasPermission("gridworld.merge.start")
+				&& <Button key="merge_map" onClick={() => navigate("/gridworld/merge_map")}>Merge map</Button>,
 			]}
 		/>
 		<p>This plugin handles creation, configuration and management of gridworlds.</p>

--- a/web/providers/useGridworlds.jsx
+++ b/web/providers/useGridworlds.jsx
@@ -1,0 +1,23 @@
+import React, { useEffect, useState } from "react";
+
+export default function useGridworlds(control) {
+	let plugin = control.plugins.get("gridworld");
+	let [gridworlds, setGridworlds] = useState(new Map(plugin.gridworlds));
+
+	useEffect(() => {
+		function update(gridworld) {
+			plugin.gridworlds.set(gridworld.id, gridworld);
+			setGridworlds(new Map(plugin.gridworlds));
+		}
+
+		const updateHandler = {
+			callback: update,
+			type: "gridworlds",
+		};
+		plugin.onUpdate(updateHandler);
+		return () => {
+			plugin.offUpdate(updateHandler);
+		};
+	}, []);
+	return gridworlds;
+}


### PR DESCRIPTION
Resolves #13 

As per issue #13 over 2 years ago now, gridworld is designed with the intent for the maps to be able to be merged together and to run as a single instance. This is done by running every map on the same seed but a different position offset. The borders align exactly in terms of world coordinates.

This makes map merging about as simple as it can be. What is implemented in this PR is the following:

1. Start a new server to perform the map merge
2. Pre-generate all chunks that are inside the generated instances
3. For each instance in the cluster, do the following:
    1. Delete all entities
    2. Serialize all tiles and set them in the same location on the target server
    3. Serialize all entities and set them in the same location on the target server

The difficult part is the last step - serializing and deserializing entities. As you might imagine, there are a lot of different entities in factorio, with a lot of different unique properties. Factorio does not provide *any* method of serializing entities - in the base game you can simply do .clone if you want to do this, but it has no intermediate representation.

The entity serializer as part of this PR aims to serialize and deserialze all properties on factorio entities. This will most likely not be achieved in quite some time, and I expect there to be follow up PRs with additional properties as we discover things that are missing.

- [x] Start merging server
- [x] Pre generate chunks
- [x] Delete entities
- [x] Serialize and move tiles
- [x] Serialize and move entities